### PR TITLE
More values in channel info

### DIFF
--- a/src/legend_data.jl
+++ b/src/legend_data.jl
@@ -236,6 +236,14 @@ function channel_info(data::LegendData, filekey::FileKey)
             system = Symbol(chmap[k].system)::Symbol,
             processable = Bool(dpcfg[k].processable)::Bool,
             usability = (dpcfg[k].usability == "on")::Bool,
+            string = chmap[k].location.string,
+            position = chmap[k].location.position,
+            cc4 = chmap[k].electronics.cc4.id,
+            cc4ch = chmap[k].electronics.cc4.channel,
+            daqcrate = chmap[k].daq.crate,
+            daqcard = chmap[k].daq.card.id,
+            hvcard = chmap[k].voltage.card.id,
+            hvch = chmap[k].voltage.channel,
         )
     end
 


### PR DESCRIPTION
Added string number, string position, HV card, DAQ card and CC4 card to the channel info creator to have more values accessible for sorting detectors. Especially useful if you want e.g. to investigate just one string, build visualization maps or look into specific electronic cards and their effects on the detectors. Screenshot shows example table:
<img width="1007" alt="image" src="https://github.com/legend-exp/LegendDataManagement.jl/assets/46198814/5729ffdb-0438-41ac-8638-37c11ba99693">
@oschulz The naming of the columns in the table can changed. This is just my proposal.