### PR TITLE
Change Usability Key

### DIFF
--- a/src/legend_data.jl
+++ b/src/legend_data.jl
@@ -236,6 +236,14 @@ function channel_info(data::LegendData, filekey::FileKey)
             system = Symbol(chmap[k].system)::Symbol,
             processable = Bool(dpcfg[k].processable)::Bool,
             usability = (dpcfg[k].usability == "on")::Bool,
+            string = chmap[k].location.string,
+            position = chmap[k].location.position,
+            cc4 = chmap[k].electronics.cc4.id,
+            cc4ch = chmap[k].electronics.cc4.channel,
+            daqcrate = chmap[k].daq.crate,
+            daqcard = chmap[k].daq.card.id,
+            hvcard = chmap[k].voltage.card.id,
+            hvch = chmap[k].voltage.channel,
         )
     end
 

--- a/src/legend_data.jl
+++ b/src/legend_data.jl
@@ -237,7 +237,7 @@ function channel_info(data::LegendData, filekey::FileKey)
             rawid = rawid,
             system = Symbol(chmap[k].system)::Symbol,
             processable = Bool(dpcfg[k].processable)::Bool,
-            usability = (dpcfg[k].usability == "on")::Bool,
+            usability = Symbol(dpcfg[k].usability)::Symbol,
             string = chmap[k].location.string,
             position = chmap[k].location.position,
             cc4 = chmap[k].electronics.cc4.id,

--- a/test/test_legend_data.jl
+++ b/test/test_legend_data.jl
@@ -26,6 +26,6 @@ include("testing_utils.jl")
     # ToDo: Make type-stable:
     @test #=@inferred=#(channel_info(l200, filekey)) isa StructArray
     chinfo = channel_info(l200, filekey)
-    @test all(filterby(@pf $processable && $usability)(chinfo).processable)
-    @test all(filterby(@pf $processable && $usability)(chinfo).usability)
+    @test all(filterby(@pf $processable && $usability == :on)(chinfo).processable)
+    @test all(filterby(@pf $processable && $usability == :on)(chinfo).usability .== :on)
 end


### PR DESCRIPTION
The usability key in the metadata has different meaning and treating it static as `"on" = true` is not enough since some channels have `no_psd` and `ac` and have to be processed anyhow. Changed this field to be a Symbol so that different selections can be performed. 
<img width="878" alt="image" src="https://github.com/legend-exp/LegendDataManagement.jl/assets/46198814/9d42ebc3-a541-4c4a-9272-73cbf422df30">
