### PR TITLE
Processing updates

### DIFF
--- a/src/LegendDataManagement.jl
+++ b/src/LegendDataManagement.jl
@@ -21,7 +21,7 @@ using Printf: @printf
 using IntervalSets: AbstractInterval, ClosedInterval, leftendpoint, rightendpoint
 using LRUCache: LRU
 using ProgressMeter: @showprogress
-using PropertyFunctions: PropertyFunction, @pf
+using PropertyFunctions: PropertyFunction, @pf, filterby
 using StaticStrings: StaticString
 using Tables: columns
 

--- a/src/dataprod_config.jl
+++ b/src/dataprod_config.jl
@@ -150,7 +150,9 @@ end
 Return `true` if `run` is an analysis run for `data` in `period`.
 """
 function is_analysis_run(data::LegendData, period::DataPeriod, run::DataRun)
-    if pydataprod_config(data).analysis_runs[Symbol(period)] == "all"
+    if !(period in keys(pydataprod_config(data).analysis_runs))
+        return false
+    elseif pydataprod_config(data).analysis_runs[Symbol(period)] == "all"
         return true
     else
         return string(run) in pydataprod_config(data).analysis_runs[Symbol(period)]

--- a/src/dataprod_config.jl
+++ b/src/dataprod_config.jl
@@ -144,6 +144,19 @@ function _resolve_partition_runs(data::LegendData, period::DataPeriod, runs::Abs
     end
 end
 
+"""
+    is_analysis_run(data::LegendData, period::DataPeriod, run::DataRun)
+
+Return `true` if `run` is an analysis run for `data` in `period`.
+"""
+function is_analysis_run(data::LegendData, period::DataPeriod, run::DataRun)
+    if pydataprod_config(data).analysis_runs[Symbol(period)] == "all"
+        return true
+    else
+        return string(run) in pydataprod_config(data).analysis_runs[Symbol(period)]
+    end
+end
+export is_analysis_run
 
 const _cached_bad_filekeys = LRU{UInt, Set{FileKey}}(maxsize = 10)
 

--- a/src/dataprod_config.jl
+++ b/src/dataprod_config.jl
@@ -160,6 +160,37 @@ function is_analysis_run(data::LegendData, period::DataPeriod, run::DataRun)
 end
 export is_analysis_run
 
+
+function _get_runinfo(data::LegendData, period::DataPeriodLike, run::DataRunLike, category::DataCategoryLike, key::Symbol)
+    data.metadata.dataprod.runinfo[Symbol(period)][Symbol(run)][Symbol(category)][key]
+end
+
+"""
+    start_key(data::LegendData, period::DataPeriodLike, run::DataRunLike, category::DataCategoryLike)
+
+Get the starting filekey for `data` in `period`, `run`, `category`.
+"""
+function start_key(data::LegendData, period::DataPeriodLike, run::DataRunLike, category::DataCategoryLike)
+    return FileKey(
+        data.name,
+        period,
+        run,
+        category,
+        Timestamp(_get_runinfo(data, period, run, category, :start_key))
+    )
+end
+export start_key
+
+"""
+    phy_livetime(data::LegendData, period::DataPeriodLike, run::DataRunLike)
+
+Get the livetime for `data` in physics data taking of `run` in `period`.
+"""
+function phy_livetime(data::LegendData, period::DataPeriodLike, run::DataRunLike)
+    _get_runinfo(data, period, run, :phy, :livetime_in_s)*u"s"
+end
+export phy_livetime
+
 const _cached_bad_filekeys = LRU{UInt, Set{FileKey}}(maxsize = 10)
 
 """

--- a/src/dataprod_config.jl
+++ b/src/dataprod_config.jl
@@ -149,8 +149,9 @@ end
 
 Return `true` if `run` is an analysis run for `data` in `period`.
 """
-function is_analysis_run(data::LegendData, period::DataPeriod, run::DataRun)
-    if !(period in keys(pydataprod_config(data).analysis_runs))
+function is_analysis_run(data::LegendData, period::DataPeriodLike, run::DataRunLike)
+    period, run = DataPeriod(period), DataRun(run)
+    if !(Symbol(period) in keys(pydataprod_config(data).analysis_runs))
         return false
     elseif pydataprod_config(data).analysis_runs[Symbol(period)] == "all"
         return true

--- a/src/filekey.jl
+++ b/src/filekey.jl
@@ -230,6 +230,19 @@ Anything that can represent a data run, like `DataRun(6)` or "r006".
 DataRunLike = Union{DataRun, Symbol, AbstractString}
 export DataRunLike
 
+"""
+    struct RunSelLike = Tuple{<:DataPeriodLike, <:DataRunLike}  
+
+Represents a LEGEND run selection.
+"""
+const RunSelLike = Tuple{<:DataPeriodLike, <:DataRunLike}  
+
+"""
+    struct RunCategorySelLike = Tuple{<:DataPeriodLike, <:DataRunLike}  
+
+Represents a LEGEND run selection for a specific `category`.
+"""
+const RunCategorySelLike = Tuple{<:DataPeriodLike, <:DataRunLike, <:DataCategoryLike}
 
 """
     struct DataCategory <: DataSelector

--- a/src/filekey.jl
+++ b/src/filekey.jl
@@ -157,7 +157,12 @@ function DataPeriod(s::AbstractString)
     end
 end
 
+function DataPeriod(s::Symbol) 
+    DataPeriod(string(s)) 
+end
+
 Base.convert(::Type{DataPeriod}, s::AbstractString) = DataPeriod(s)
+Base.convert(::Type{DataPeriod}, s::Symbol) = DataPeriod(string(s))
 
 
 """
@@ -165,7 +170,7 @@ Base.convert(::Type{DataPeriod}, s::AbstractString) = DataPeriod(s)
 
 Anything that can represent a data period, like `DataPeriod(2)` or "p02".
 """
-const DataPeriodLike = Union{DataPeriod, AbstractString}
+const DataPeriodLike = Union{DataPeriod, Symbol, AbstractString}
 export DataPeriodLike
 
 
@@ -210,14 +215,19 @@ function DataRun(s::AbstractString)
     end
 end
 
+function DataRun(s::Symbol) 
+    DataRun(string(s)) 
+end
+
 Base.convert(::Type{DataRun}, s::AbstractString) = DataRun(s)
+Base.convert(::Type{DataRun}, s::Symbol) = DataRun(string(s))
 
 """
     DataRunLike = Union{DataRun, Integer, AbstractString}
 
 Anything that can represent a data run, like `DataRun(6)` or "r006".
 """
-DataRunLike = Union{DataRun, AbstractString}
+DataRunLike = Union{DataRun, Symbol, AbstractString}
 export DataRunLike
 
 

--- a/src/filekey.jl
+++ b/src/filekey.jl
@@ -231,20 +231,6 @@ DataRunLike = Union{DataRun, Symbol, AbstractString}
 export DataRunLike
 
 """
-    struct RunSelLike = Tuple{<:DataPeriodLike, <:DataRunLike}  
-
-Represents a LEGEND run selection.
-"""
-const RunSelLike = Tuple{<:DataPeriodLike, <:DataRunLike}  
-
-"""
-    struct RunCategorySelLike = Tuple{<:DataPeriodLike, <:DataRunLike}  
-
-Represents a LEGEND run selection for a specific `category`.
-"""
-const RunCategorySelLike = Tuple{<:DataPeriodLike, <:DataRunLike, <:DataCategoryLike}
-
-"""
     struct DataCategory <: DataSelector
 
 Represents a LEGEND data category (related to a DAQ/measuring mode) like
@@ -297,6 +283,19 @@ const DataCategoryLike = Union{DataCategory, Symbol, AbstractString}
 export DataCategoryLike
 
 
+"""
+    struct RunSelLike = Tuple{<:DataPeriodLike, <:DataRunLike}  
+
+Represents a LEGEND run selection.
+"""
+const RunSelLike = Tuple{<:DataPeriodLike, <:DataRunLike}
+
+"""
+    struct RunCategorySelLike = Tuple{<:DataPeriodLike, <:DataRunLike}  
+
+Represents a LEGEND run selection for a specific `category`.
+"""
+const RunCategorySelLike = Tuple{<:DataPeriodLike, <:DataRunLike, <:DataCategoryLike}
 
 """
     struct Timestamp <: DataSelector

--- a/src/legend_data.jl
+++ b/src/legend_data.jl
@@ -281,7 +281,7 @@ end
 export channelinfo
 
 function channelinfo(data::LegendData, sel::Tuple{DataPeriodLike, DataRunLike, DataCategoryLike})
-    channelinfo(data, start_key(data, sel[1], sel[2], sel[3]))
+    channelinfo(data, start_filekey(data, sel[1], sel[2], sel[3]))
 end
 
 function channelinfo(data::LegendData, sel::Union{AnyValiditySelection, Tuple{DataPeriodLike, DataRunLike, DataCategoryLike}},; system::Symbol=:geds, processable::Bool=true)


### PR DESCRIPTION
Added functionality which was so far in the dataflow:

- `is_analysis_run` checks if the run is a analysis run
- `start_key` returns the starting FileKey for a given period and run
- `phy_livetime` returns the livetime for a given run and period

Also, I extended the `channelinfo` to be able to get the info for a given run and period by using the `start_key` as a reference and also to get a handy access to the `:geds` subsytem with 
``` julia
channelinfo(l200, (:p03, :r000, :cal))
channelinfo(l200, (:p03, :r000, :cal); system=:geds, processable=true)
```
This makes this whole process of getting filekeys etc way more handy and the user can just get the `channelinfo` for a given run much more human readable.

I will also move some of the `addprocs` functionality and try to start with some of the logging stuff. 
Maybe @oschulz, you could also share some ideas here. The missing features are here a way to first create Markdown logs and then write them. 
Then, a function `savelegendfig` would be nice which automatically generates figure names and saves a given figure.
And the option to save units in the `PropDicts` as discussed. 