### PR TITLE
Bug Fixes

### DIFF
--- a/src/dataprod_config.jl
+++ b/src/dataprod_config.jl
@@ -103,15 +103,15 @@ export pydataprod_parameters
 
 
 """
-    data_partitions(data::LegendData, label::Symbol = :default)
+    partitioninfo(data::LegendData, label::Symbol = :default)
 
 Return cross-period data partitions.
 """
-function data_partitions(data::LegendData, label::Symbol = :default)
+function partitioninfo(data::LegendData, label::Symbol = :default)
     parts = pydataprod_config(data).partitions[label]
     pidxs = Int.(keys(parts))
     result::IdDict{
-        Int,
+        DataPartition,
         StructVector{
             @NamedTuple{period::DataPeriod, run::DataRun},
             @NamedTuple{period::Vector{DataPeriod}, run::Vector{DataRun}},
@@ -126,14 +126,19 @@ function data_partitions(data::LegendData, label::Symbol = :default)
                 for (p,rs) in part
             ]
             flat_pr = vcat(periods_and_runs...)::Vector{@NamedTuple{period::DataPeriod, run::DataRun}}
-            pidx::Int => StructArray(flat_pr)
+            DataPartition(pidx)::DataPartition => StructArray(flat_pr)
         end
         for (pidx, part) in parts
     ])
 
     return result
 end
+export partitioninfo
+
+
+@deprecate data_partitions(data::LegendData, label::Symbol = :default) IdDict([k.no => v for (k, v) in partitioninfo(data, label)])
 export data_partitions
+
 
 _resolve_partition_runs(data::LegendData, period::DataPeriod, runs::AbstractVector) = Vector{DataRun}(runs)
 function _resolve_partition_runs(data::LegendData, period::DataPeriod, runs::AbstractString)

--- a/src/filekey.jl
+++ b/src/filekey.jl
@@ -145,9 +145,9 @@ Base.:(==)(a::DataPartition, b::DataPartition) = a.no == b.no
 Base.isless(a::DataPartition, b::DataPartition) = isless(a.no, b.no)
 
 # ToDo: Improve implementation
-Base.print(io::IO, partition::DataPartition) = print(io, "partition$(lpad(string(partition.no), 2, string(0)))")
+Base.print(io::IO, partition::DataPartition) = print(io, "part$(lpad(string(partition.no), 2, string(0)))")
 
-const partition_expr = r"^partition([0-9]{2})$"
+const partition_expr = r"^part([0-9]{2})$"
 
 _can_convert_to(::Type{DataPartition}, s::AbstractString) = !isnothing(match(partition_expr, s))
 

--- a/src/filekey.jl
+++ b/src/filekey.jl
@@ -10,6 +10,10 @@ Abstract type for data selectors like
 """
 abstract type DataSelector end
 
+# make DataSelector compatible with PropDicts
+Base.getindex(p::PropDicts.PropDict, datasel::DataSelector) = p[Symbol(datasel)]
+Base.setindex!(p::PropDict, value, datasel::DataSelector) = setindex!(p, value, Symbol(datasel))
+Base.haskey(p::PropDicts.PropDict, datasel::DataSelector) = haskey(p, Symbol(datasel))
 
 """
     struct ExpSetup <: DataSelector
@@ -668,7 +672,6 @@ Base.convert(::Type{DetectorId}, s::Symbol) = DetectorId(s)
 
 Base.Symbol(detector::DetectorId) = detector.label
 Base.convert(::Type{Symbol}, detector::DetectorId) = detector.label
-Base.getindex(p::PropDicts.PropDict, detector::DetectorId) = p[detector.label]
 
 # ToDo: Improve implementation
 Base.print(io::IO, detector::DetectorId) = print(io, detector.label)

--- a/src/filekey.jl
+++ b/src/filekey.jl
@@ -116,6 +116,63 @@ const DataTierLike = Union{DataTier, Symbol, AbstractString}
 export DataTierLike
 
 
+"""
+    struct DataPartition <: DataSelector
+
+Represents a LEGEND data-taking partition.
+
+Example:
+
+```julia
+partition = DataPartition(1)
+partition.no == 1
+string(partition) == "partition01"
+DataPartition("partiton01") == partition
+```
+"""
+struct DataPartition <: DataSelector
+    no::Int
+end
+export DataPartition
+
+@inline DataPartition(partition::DataPartition) = partition
+
+Base.:(==)(a::DataPartition, b::DataPartition) = a.no == b.no
+Base.isless(a::DataPartition, b::DataPartition) = isless(a.no, b.no)
+
+# ToDo: Improve implementation
+Base.print(io::IO, partition::DataPartition) = print(io, "partition$(lpad(string(partition.no), 2, string(0)))")
+
+const partition_expr = r"^partition([0-9]{2})$"
+
+_can_convert_to(::Type{DataPartition}, s::AbstractString) = !isnothing(match(partition_expr, s))
+
+function DataPartition(s::AbstractString)
+    m = match(partition_expr, s)
+    if (m == nothing)
+        throw(ArgumentError("String \"$s\" does not look like a valid file LEGEND data-partition name"))
+    else
+        DataPartition(parse(Int, (m::RegexMatch).captures[1]))
+    end
+end
+
+function DataPartition(s::Symbol) 
+    DataPartition(string(s)) 
+end
+
+Base.convert(::Type{DataPartition}, s::AbstractString) = DataPartition(s)
+Base.convert(::Type{DataPartition}, s::Symbol) = DataPartition(string(s))
+
+
+"""
+    DataPartitionLike = Union{DataPartition, Symbol, AbstractString}
+
+Anything that can represent a data partition, like `DataPartition(2)` or "partition02".
+"""
+const DataPartitionLike = Union{DataPartition, Symbol, AbstractString}
+export DataPartitionLike
+
+
 
 """
     struct DataPeriod <: DataSelector
@@ -166,7 +223,7 @@ Base.convert(::Type{DataPeriod}, s::Symbol) = DataPeriod(string(s))
 
 
 """
-    DataPeriodLike = Union{DataPeriod, Integer, AbstractString}
+    DataPeriodLike = Union{DataPeriod, Symbol, AbstractString}
 
 Anything that can represent a data period, like `DataPeriod(2)` or "p02".
 """
@@ -223,7 +280,7 @@ Base.convert(::Type{DataRun}, s::AbstractString) = DataRun(s)
 Base.convert(::Type{DataRun}, s::Symbol) = DataRun(string(s))
 
 """
-    DataRunLike = Union{DataRun, Integer, AbstractString}
+    DataRunLike = Union{DataRun, Symbol, AbstractString}
 
 Anything that can represent a data run, like `DataRun(6)` or "r006".
 """

--- a/src/filekey.jl
+++ b/src/filekey.jl
@@ -668,6 +668,7 @@ Base.convert(::Type{DetectorId}, s::Symbol) = DetectorId(s)
 
 Base.Symbol(detector::DetectorId) = detector.label
 Base.convert(::Type{Symbol}, detector::DetectorId) = detector.label
+Base.getindex(p::PropDicts.PropDict, detector::DetectorId) = p[detector.label]
 
 # ToDo: Improve implementation
 Base.print(io::IO, detector::DetectorId) = print(io, detector.label)

--- a/src/legend_data.jl
+++ b/src/legend_data.jl
@@ -297,7 +297,7 @@ end
 Get channel information validitiy selection and [`DetectorId`](@ref) resp.
 [`ChannelId`](@ref).
 """
-function channelinfo(data::LegendData, sel::AnyValiditySelection, channel::ChannelIdLike; kwargs...)
+function channelinfo(data::LegendData, sel::Union{AnyValiditySelection, RunCategorySelLike}, channel::ChannelIdLike; kwargs...)
     chinfo = channelinfo(data, sel; kwargs...)
     idxs = findall(x -> ChannelId(x) == ChannelId(channel), chinfo.channel)
     if isempty(idxs)
@@ -309,7 +309,7 @@ function channelinfo(data::LegendData, sel::AnyValiditySelection, channel::Chann
     end
 end
 
-function channelinfo(data::LegendData, sel::AnyValiditySelection, detector::DetectorIdLike; kwargs...)
+function channelinfo(data::LegendData, sel::Union{AnyValiditySelection, RunCategorySelLike}, detector::DetectorIdLike; kwargs...)
     chinfo = channelinfo(data, sel; kwargs...)
     idxs = findall(x -> DetectorId(x) == DetectorId(detector), chinfo.detector)
     if isempty(idxs)


### PR DESCRIPTION
- Fixed problems for `channelinfo` together with `RunCategorySelLike` for `channelinfo` with a single `DetectorId` as inpu
- Added `DataPartition` struct to be used for parititons and therefore the naming within all future partitioning functions
- Made `DataSelector` compatible with `PropDicts`. Otherwise, this doesn't work:
``` julia
dets = channelinfo(l200, (:p03, :r000, :cal); system=:geds, only_processable=true).detector
l200.par.rpars.ecal.p03.r000[dets[1]]
```
