### PR TITLE
Bugfix in parsing `LegendDataConfig` on Windows

### DIFF
--- a/src/data_config.jl
+++ b/src/data_config.jl
@@ -156,7 +156,7 @@ end
 
 function LegendDataConfig()
     if haskey(ENV, _data_config_envvar_name)
-        config_filenames = reverse(String.(split(ENV[_data_config_envvar_name], ':')))
+        config_filenames = reverse(String.(split(ENV[_data_config_envvar_name], r":(?!\\)")))
         LegendDataConfig(config_filenames)
     else
         throw(ErrorException("Environment variable $_data_config_envvar_name not set"))


### PR DESCRIPTION
The tests on Windows keep on failing since implementing the support for colon-separated filenames in `LEGEND_DATA_CONFIG` in commit https://github.com/legend-exp/LegendDataManagement.jl/commit/80b0c1182433693b4a298ee8670f8f9d933ba99a.

What happens is that `LEGEND_DATA_CONFIG` is split at every colon, including the colons that might belong to a Windows file path (`C:\\...`). In this PR, I replaced the simple `':'` as the split condition with a regular expression `r":(?!\\)` to avoid splitting `:\\` as expected in Windows file paths.

I hope that the tests on Windows will pass again with this fix.