### PR TITLE
LegendReport can talk with DataSelectors and rounds numbers

### DIFF
--- a/src/filekey.jl
+++ b/src/filekey.jl
@@ -15,6 +15,10 @@ Base.getindex(p::PropDicts.PropDict, datasel::DataSelector) = p[Symbol(datasel)]
 Base.setindex!(p::PropDict, value, datasel::DataSelector) = setindex!(p, value, Symbol(datasel))
 Base.haskey(p::PropDicts.PropDict, datasel::DataSelector) = haskey(p, Symbol(datasel))
 
+_markdown_cell_content(@nospecialize(content::DataSelector)) = string(content)
+lreport!(rpt::LegendReport, @nospecialize(sel::DataSelector)) = lreport!(rpt, string(sel))
+
+
 """
     struct ExpSetup <: DataSelector
 

--- a/src/legend_report.jl
+++ b/src/legend_report.jl
@@ -168,6 +168,9 @@ function lreport!(rpt::LegendReport, @nospecialize(markdown_str::AbstractString)
     lreport!(rpt, Markdown.parse(markdown_str))
 end
 
+lreport!(rpt::LegendReport, @nospecialize(number::AbstractFloat)) = lreport!(rpt, string(round(number, digits=3)))
+lreport!(rpt::LegendReport, @nospecialize(number::Quantity{<:Real})) = lreport!(rpt, string(round(unit(number), number, digits=3)))
+
 
 """
     LegendDataManagement.lreport_for_show!(rpt::LegendReport, mime::MIME, content)
@@ -220,6 +223,7 @@ _markdown_cell_content(@nospecialize(content::Expr)) = string(content)
 _markdown_cell_content(@nospecialize(content::Number)) = _show_plain_compact(content)
 _markdown_cell_content(@nospecialize(content::AbstractInterval)) = _show_plain_compact(content)
 _markdown_cell_content(@nospecialize(content::Array)) = _show_plain_compact(content)
+
 
 _show_plain_compact(@nospecialize(content)) = sprint(show, content; context = :compact=>true)
 


### PR DESCRIPTION
Need to be able to pass DataSelectors and round numbers automatically to have cleaner reports.
Rounding is temp and can be removed, but I would still merge to have a stable release now for all the data production since I am already using that actively.