### PR TITLE
Bug Fixes + Updated calibration functions

### DIFF
--- a/src/calibration_functions.jl
+++ b/src/calibration_functions.jl
@@ -1,54 +1,67 @@
 # This file is a part of LegendDataManagement.jl, licensed under the MIT License (MIT).
 
-const _cached_get_ecal_props = LRU{Tuple{UInt, ValiditySelection}, Union{PropDict,PropDicts.MissingProperty}}(maxsize = 10^3)
+const _cached_get_ecal_props = LRU{Tuple{UInt, AnyValiditySelection}, Union{PropDict,PropDicts.MissingProperty}}(maxsize = 10^3)
 
-function _get_ecal_props(data::LegendData, sel::ValiditySelection)
+function _get_ecal_props(data::LegendData, sel::AnyValiditySelection)
     key = (objectid(data), sel)
     get!(_cached_get_ecal_props, key) do
-        dataprod_parameters(data).cal.energy(sel)
+        get_values(dataprod_parameters(data).rpars.ecal(sel))
     end
 end
 
-function _get_ecal_props(data::LegendData, sel::ValiditySelection, detector::DetectorId)
+function _get_ecal_props(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
     _get_ecal_props(data, sel)[Symbol(detector)]
 end
 
+const _cached_get_ctc_props = LRU{Tuple{UInt, AnyValiditySelection}, Union{PropDict,PropDicts.MissingProperty}}(maxsize = 10^3)
 
-const _cached_get_psdcal_props = LRU{Tuple{UInt, ValiditySelection}, Union{PropDict,PropDicts.MissingProperty}}(maxsize = 10^3)
-
-function _get_psdcal_props(data::LegendData, sel::ValiditySelection)
+function _get_ctc_props(data::LegendData, sel::AnyValiditySelection)
     key = (objectid(data), sel)
-    get!(_cached_get_psdcal_props, key) do
-        dataprod_parameters(data).cal.psd(sel)
+    get!(_cached_get_ctc_props, key) do
+        get_values(dataprod_parameters(data).rpars.ctc(sel))
     end
 end
 
-function _get_psdcal_props(data::LegendData, sel::ValiditySelection, detector::DetectorId)
-    _get_psdcal_props(data, sel)[Symbol(detector)].calibration
+function _get_ctc_props(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
+    _get_ctc_props(data, sel)[Symbol(detector)]
+end
+
+
+const _cached_get_psdcal_props = LRU{Tuple{UInt, AnyValiditySelection}, Union{PropDict,PropDicts.MissingProperty}}(maxsize = 10^3)
+
+function _get_psdcal_props(data::LegendData, sel::AnyValiditySelection)
+    key = (objectid(data), sel)
+    get!(_cached_get_psdcal_props, key) do
+        get_values(dataprod_parameters(data).rpars.aoecal(sel))
+    end
+end
+
+function _get_psdcal_props(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
+    _get_psdcal_props(data, sel)[Symbol(detector)]
 end
 
 #=
-function _get_e_cal_function(data::LegendData, sel::ValiditySelection, channel::ChannelId, e_filter::Symbol)
+function _get_e_cal_function(data::LegendData, sel::AnyValiditySelection, channel::ChannelId, e_filter::Symbol)
     detector = channelinfo(data, sel, channel).detector
     _get_e_cal_function(data, sel, detector, e_filter)
 end
 =#
 
-function _get_e_cal_function(data::LegendData, sel::ValiditySelection, detector::DetectorId, e_filter::Symbol)
+function _get_e_cal_function(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, e_filter::Symbol)
     ecal_props = _get_ecal_props(data, sel, detector)
-    cal_pars = ecal_props[e_filter].energy
+    cal_pars = ecal_props[e_filter]
 
-    cal_slope::Float64 = get(cal_pars, :m_calib, NaN)
-    cal_offset::Float64 = get(cal_pars, :n_calib, NaN)
+    cal_slope::Unitful.Energy{Float64} = get(cal_pars, :m_calib, NaN*u"keV")
+    cal_offset::Unitful.Energy{Float64} = get(cal_pars, :n_calib, NaN*u"keV")
 
-    let cal_slope = cal_slope * u"keV", cal_offset = cal_offset * u"keV"
+    let cal_slope = cal_slope, cal_offset = cal_offset
         return _calib_energy(e_uncal::Real) = cal_slope * e_uncal + cal_offset
     end
 end
 
 
 #=
-function get_e_cal_propfunc(data::LegendData, sel::ValiditySelection, channel::ChannelId, e_filter::Symbol)
+function get_e_cal_propfunc(data::LegendData, sel::AnyValiditySelection, channel::ChannelId, e_filter::Symbol)
     get_e_cal_propfunc(data, sel, channel, Val(e_filter))
 end
 export get_e_cal_propfunc
@@ -56,7 +69,7 @@ export get_e_cal_propfunc
 for e_filter in (:e_trap, :e_cusp, :e_zac)
     e_col_sym = Expr(:$, e_filter)
     @eval begin
-        function get_e_cal_propfunc(data::LegendData, sel::ValiditySelection, channel::ChannelId, ::Val{$(Meta.quot(e_filter))})
+        function get_e_cal_propfunc(data::LegendData, sel::AnyValiditySelection, channel::ChannelId, ::Val{$(Meta.quot(e_filter))})
             let _calib_energy = _get_e_cal_function(data, sel, channel, $(Meta.quot(e_filter)))
                 @pf _calib_energy($e_col_sym)
             end
@@ -67,23 +80,22 @@ end
 
 
 #=
-function _get_e_ctc_cal_function(data::LegendData, sel::ValiditySelection, channel::ChannelId, e_filter::Symbol)
+function _get_e_ctc_cal_function(data::LegendData, sel::AnyValiditySelection, channel::ChannelId, e_filter::Symbol)
     detector = channelinfo(data, sel, channel).detector
     _get_e_ctc_cal_function(data, sel, detector, e_filter)
 end
 =#
 
-function _get_e_ctc_cal_function(data::LegendData, sel::ValiditySelection, detector::DetectorId, e_filter::Symbol)
+function _get_e_ctc_cal_function(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, e_filter::Symbol)
     e_filter_ctc = Symbol("$(e_filter)_ctc")
-    ecal_props = _get_ecal_props(data, sel, detector)
-    ctc_pars = ecal_props[e_filter].ctc
-    post_ctc_cal_pars = ecal_props[e_filter_ctc].energy
+    ctc_pars = _get_ctc_props(data, sel, detector)[e_filter].ctc
+    post_ctc_cal_pars = _get_ecal_props(data, sel, detector)[e_filter_ctc]
 
     fct::Float64 = get(ctc_pars, :fct, NaN)
-    cal_slope::Float64 = get(post_ctc_cal_pars, :m_calib, NaN)
-    cal_offset::Float64 = get(post_ctc_cal_pars, :n_calib, NaN)
+    cal_slope::Unitful.Energy{Float64} = get(post_ctc_cal_pars, :m_calib, NaN*u"keV")
+    cal_offset::Unitful.Energy{Float64} = get(post_ctc_cal_pars, :n_calib, NaN*u"keV")
 
-    let cal_slope = cal_slope * u"keV", cal_offset = cal_offset * u"keV", fct = fct
+    let cal_slope = cal_slope, cal_offset = cal_offset, fct = fct
         return function _calib_energy(e_uncal::Real, qdrift::Real)
             cal_slope * (e_uncal + fct * qdrift) + cal_offset
         end
@@ -91,7 +103,7 @@ function _get_e_ctc_cal_function(data::LegendData, sel::ValiditySelection, detec
 end
 
 #=
-function get_e_ctc_cal_propfunc(data::LegendData, sel::ValiditySelection, channel::ChannelId, e_filter::Symbol)
+function get_e_ctc_cal_propfunc(data::LegendData, sel::AnyValiditySelection, channel::ChannelId, e_filter::Symbol)
     get_e_ctc_cal_propfunc(data, sel, channel, Val(e_filter))
 end
 export get_e_ctc_cal_propfunc
@@ -100,7 +112,7 @@ for e_filter in (:e_trap, :e_cusp, :e_zac)
     e_col_sym = Expr(:$, e_filter)
     qdrift_sym = Expr(:$, :qdrift)
     @eval begin
-        function get_e_ctc_cal_propfunc(data::LegendData, sel::ValiditySelection, channel::ChannelId, ::Val{$(Meta.quot(e_filter))})
+        function get_e_ctc_cal_propfunc(data::LegendData, sel::AnyValiditySelection, channel::ChannelId, ::Val{$(Meta.quot(e_filter))})
             let _calib_energy = _get_e_ctc_cal_function(data, sel, channel, $(Meta.quot(e_filter)))
                 @pf _calib_energy($e_col_sym, $qdrift_sym)
             end
@@ -111,7 +123,7 @@ end
 
 
 #=
-function _get_aoe_cal_function(data::LegendData, sel::ValiditySelection, channel::ChannelId)
+function _get_aoe_cal_function(data::LegendData, sel::AnyValiditySelection, channel::ChannelId)
     detector = channelinfo(data, sel, channel).detector
     _get_aoe_cal_function(data, sel, detector)
 end
@@ -121,23 +133,23 @@ _f_aoe_sigma(x, p) = sqrt(abs(p[1]) + abs(p[2])/x^2)
 _f_aoe_mu(x, p) = p[1] .+ p[2]*x
 
 
-function _get_aoe_cal_function(data::LegendData, sel::ValiditySelection, detector::DetectorId, e_filter::Symbol)
+function _get_aoe_cal_function(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, e_filter::Symbol)
     ecal_props = _get_ecal_props(data, sel, detector)
-    cal_pars = ecal_props[e_filter].energy
+    cal_pars = ecal_props[e_filter]
     psdcal_props = _get_psdcal_props(data, sel, detector)
 
-    cal_slope::Float64 = get(cal_pars, :m_calib, NaN)
-    cal_offset::Float64 = get(cal_pars, :n_calib, NaN)
-    μ_scs::NTuple{2,Float64} = (get(psdcal_props, :μ_scs, fill(NaN, 2))...,)
-    σ_scs::NTuple{2,Float64} = (get(psdcal_props, :σ_scs, fill(NaN, 2))...,)
+    cal_slope::Unitful.Energy{Float64} = get(cal_pars, :m_calib, NaN*u"keV")
+    cal_offset::Unitful.Energy{Float64} = get(cal_pars, :n_calib, NaN*u"keV")
+    μ_scs::Tuple{Float64, Quantity{Float64}} = (get(psdcal_props, :μ_scs, [NaN, NaN*u"keV^-1"])...,)
+    σ_scs::Tuple{Float64, Quantity{Float64}} = (get(psdcal_props, :σ_scs, [NaN, NaN*u"keV^2"])...,)
 
     let cal_slope = cal_slope, cal_offset = cal_offset,
         μ_scs = μ_scs, σ_scs = σ_scs
 
         return function _calib_aoe(e_uncal::Real, a_uncal::Real)
             e_cal = cal_slope * e_uncal + cal_offset
-            aoe_raw = a_uncal / e_cal 
-            aoe_corrected = aoe_raw / _f_aoe_mu(e_cal, μ_scs) - 1
+            aoe_raw = ustrip(a_uncal / e_cal)
+            aoe_corrected = aoe_raw - _f_aoe_mu(e_cal, μ_scs)
             aoe_classifier = aoe_corrected / _f_aoe_sigma(e_cal, σ_scs)
             (aoe_raw = aoe_raw, aoe_corrected = aoe_corrected, aoe_classifier = aoe_classifier)
         end
@@ -147,7 +159,7 @@ end
 
 
 """
-    get_ged_cal_propfunc(data::LegendData, sel::ValiditySelection, detector::DetectorId)
+    get_ged_cal_propfunc(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
 
 Get the HPGe calibration function for the given data, validity selection and
 detector.
@@ -160,18 +172,20 @@ columns `e_trap_cal`, `e_cusp_cal`, `e_zac_cal`, `e_trap_ctc_cal`,
 Note: Caches configuration/calibration data internally, use a fresh `data`
 object if on-disk configuration/calibration data may have changed.
 """
-function get_ged_cal_propfunc(data::LegendData, sel::ValiditySelection, detector::DetectorId)
+function get_ged_cal_propfunc(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
     let cf_trap = _get_e_cal_function(data, sel, detector, :e_trap),
         cf_cusp = _get_e_cal_function(data, sel, detector, :e_cusp),
         cf_zac = _get_e_cal_function(data, sel, detector, :e_zac),
         cf_ctc_trap = _get_e_ctc_cal_function(data, sel, detector, :e_trap),
         cf_ctc_cusp = _get_e_ctc_cal_function(data, sel, detector, :e_cusp),
         cf_ctc_zac = _get_e_ctc_cal_function(data, sel, detector, :e_zac),
-        cf_aoe = _get_aoe_cal_function(data, sel, detector, :e_trap)
+        cf_313 = _get_e_cal_function(data, sel, detector, :e_313),
+        cf_10410 = _get_e_cal_function(data, sel, detector, :e_10410),
+        cf_aoe = _get_aoe_cal_function(data, sel, detector, :e_cusp)
 
         @pf begin
             # ToDo: Don't hardcode A/E reference energy source:
-            aoe_ref_e_uncal = $e_trap
+            aoe_ref_e_uncal = $e_cusp
             aoe_raw, aoe_corrected, aoe_classifier = cf_aoe(aoe_ref_e_uncal, $a)
 
             (
@@ -181,6 +195,8 @@ function get_ged_cal_propfunc(data::LegendData, sel::ValiditySelection, detector
                 e_trap_ctc_cal = cf_ctc_trap($e_trap, $qdrift),
                 e_cusp_ctc_cal = cf_ctc_cusp($e_cusp, $qdrift),
                 e_zac_ctc_cal = cf_ctc_zac($e_zac, $qdrift),
+                e_short_cal = cf_313($e_313),
+                e_long_cal = cf_10410($e_10410),
                 aoe_raw = aoe_raw, aoe_corrected = aoe_corrected, aoe_classifier = aoe_classifier
             )
         end
@@ -188,30 +204,25 @@ function get_ged_cal_propfunc(data::LegendData, sel::ValiditySelection, detector
 end
 export get_ged_cal_propfunc
 
-function get_ged_cal_propfunc(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
-    get_ged_cal_propfunc(data, ValiditySelection(sel), detector)
-end
 
+const _cached_dataprod_pars_p_psd = LRU{Tuple{UInt, AnyValiditySelection}, Union{PropDict,PropDicts.MissingProperty}}(maxsize = 10^3)
 
-
-const _cached_dataprod_pars_p_psd = LRU{Tuple{UInt, ValiditySelection}, Union{PropDict,PropDicts.MissingProperty}}(maxsize = 10^3)
-
-function _dataprod_pars_p_psd(data::LegendData, sel::ValiditySelection)
+function _dataprod_pars_p_psd(data::LegendData, sel::AnyValiditySelection)
     data_id = objectid(data)
     key = (objectid(data), sel)
     get!(_cached_dataprod_pars_p_psd, key) do
-        dataprod_parameters(data).cal.p_psd(sel)
+        get_values(dataprod_parameters(data).ppars.aoe(sel))
     end
 end
 
-function _dataprod_pars_p_psd(data::LegendData, sel::ValiditySelection, detector::DetectorId)
+function _dataprod_pars_p_psd(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
     _dataprod_pars_p_psd(data, sel)[Symbol(detector)]
 end
 
 
-const _cached_dataprod_qc = LRU{Tuple{UInt, ValiditySelection}, Union{PropDict,PropDicts.MissingProperty}}(maxsize = 10^3)
+const _cached_dataprod_qc = LRU{Tuple{UInt, AnyValiditySelection}, Union{PropDict,PropDicts.MissingProperty}}(maxsize = 10^3)
 
-function _dataprod_qc(data::LegendData, sel::ValiditySelection)
+function _dataprod_qc(data::LegendData, sel::AnyValiditySelection)
     data_id = objectid(data)
     key = (objectid(data), sel)
     get!(_cached_dataprod_qc, key) do
@@ -220,12 +231,12 @@ function _dataprod_qc(data::LegendData, sel::ValiditySelection)
 end
 
 
-const _cached_dataprod_qc_cuts_pf = LRU{Tuple{UInt, ValiditySelection}, PropertyFunction}(maxsize = 10^2)
+const _cached_dataprod_qc_cuts_pf = LRU{Tuple{UInt, AnyValiditySelection}, PropertyFunction}(maxsize = 10^2)
 
 
 # Will replace current get_ged_qc_cuts_propfunc in the future.
 # Currently suffers from world-age problems due to `ljl_propfunc`.
-function _get_ged_qc_cuts_propfunc_dynamic(data::LegendData, sel::ValiditySelection)
+function _get_ged_qc_cuts_propfunc_dynamic(data::LegendData, sel::AnyValiditySelection)
     data_id = objectid(data)
     key = (objectid(data), sel)
     get!(_cached_dataprod_qc_cuts_pf, key) do
@@ -236,13 +247,13 @@ end
 
 
 """
-    LegendDataManagement.get_ged_qc_cuts_propfunc(data::LegendData, sel::ValiditySelection)
+    LegendDataManagement.get_ged_qc_cuts_propfunc(data::LegendData, sel::AnyValiditySelection)
 
 Hardcoded Ge-detector quality cuts.
 
 Note: Temporary workaround for world-age problems with `ljl_propfunc`.
 """
-function get_ged_qc_cuts_propfunc(data::LegendData, sel::ValiditySelection)
+function get_ged_qc_cuts_propfunc(data::LegendData, sel::AnyValiditySelection)
     # ToDo: Replace code with _get_ged_qc_cuts_propfunc_dynamic when world-age problems
     # with ljl_propfunc are fixed.
 
@@ -252,7 +263,7 @@ function get_ged_qc_cuts_propfunc(data::LegendData, sel::ValiditySelection)
             is_downgoing_baseline = $blslope < -0.2 / (16ns),
             is_neg_energy = $e_10410_inv > 500 && ($t0_inv > 1000ns && !($e_10410_inv > 100 && ($t0_inv > 45000ns && $t0_inv < 55000ns))),
             is_negative_crosstalk = $e_10410_inv > 100 && ($t0_inv > 45000ns && $t0_inv < 55000ns),
-            is_noise_burst = $e_min - $blmean < -300 && ($e_max - $blmean > 300 && abs($rt1090) < 800ns),
+            is_noise_burst = $e_min - $blmean < -300 && ($e_max - $blmean > 300 && abs($t90 - $t10) < 800ns),
             is_nopileup = !($inTrace_intersect > $t0 + 2 * $drift_time && $inTrace_n > 1) || ($e_cusp_ctc_cal < 25kev || $e_cusp_ctc_cal != $e_cusp_ctc_cal),
             is_saturated = $n_sat_high > 0,
             is_upgoing_baseline = $blslope > 0.2 / (16ns),
@@ -260,7 +271,7 @@ function get_ged_qc_cuts_propfunc(data::LegendData, sel::ValiditySelection)
             is_valid_dteff = $qdrift / $e_10410 > -30 || ($e_cusp_ctc_cal < 25kev || $e_cusp_ctc_cal != $e_cusp_ctc_cal),
             is_valid_ediff = abs($e_10410 - $e_313) > 100 || ($e_cusp_ctc_cal < 25kev || ($e_cusp_ctc_cal != $e_cusp_ctc_cal || $n_sat_high > 0)),
             is_valid_efrac = $e_10410 / $e_313 > 0.95 && $e_10410 / $e_313 < 1.1 || ($e_cusp_ctc_cal < 25kev || ($e_cusp_ctc_cal != $e_cusp_ctc_cal || $n_sat_high > 0)),
-            is_valid_rt = $rt1090 > 96ns && $t50 - $t0 >= 16ns || ($e_cusp_ctc_cal < 25kev || $e_cusp_ctc_cal != $e_cusp_ctc_cal),
+            is_valid_rt = $t90 - $t10 > 96ns && $t50 - $t0 >= 16ns || ($e_cusp_ctc_cal < 25kev || $e_cusp_ctc_cal != $e_cusp_ctc_cal),
             is_valid_t0 = $t0 > 47000ns && $t0 < 55000ns || ($e_cusp_ctc_cal < 25kev || $e_cusp_ctc_cal != $e_cusp_ctc_cal),
             is_valid_tail = $tailsigma < 75 || (abs($blslope / $tailslope) < 0.4 && abs($blslope / $tailslope) > 2.5 || ($e_10410_inv > 100 && ($t0_inv > 45000ns && $t0_inv < 55000ns) || $n_sat_high > 0)),
         )
@@ -270,12 +281,12 @@ end
 
 # ToDo: Make configurable
 """
-    get_ged_qc_isgood_propfunc(data::LegendData, sel::ValiditySelection)
+    get_ged_qc_isgood_propfunc(data::LegendData, sel::AnyValiditySelection)
 
 Get a `PropertyFunction` that returns `true` for events that pass the
 Ge-detector quality cuts.
 """
-function get_ged_qc_isgood_propfunc(data::LegendData, sel::ValiditySelection)
+function get_ged_qc_isgood_propfunc(data::LegendData, sel::AnyValiditySelection)
     @pf begin
         !$is_discharge && !$is_downgoing_baseline && !$is_neg_energy &&
         !$is_negative_crosstalk && !$is_noise_burst && $is_nopileup &&
@@ -287,39 +298,39 @@ end
 
 
 """
-    LegendDataManagement.dataprod_pars_aoe_window(data::LegendData, sel::ValiditySelection, detector::DetectorId)
+    LegendDataManagement.dataprod_pars_aoe_window(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
 
 Get the A/E cut window for the given data, validity selection and detector.
 """
-function dataprod_pars_aoe_window(data::LegendData, sel::ValiditySelection, detector::DetectorId)
-    aoecut_lo::Float64 = get(_dataprod_pars_p_psd(data, sel, detector).aoecut, :lo, NaN)
-    aoecut_hi::Float64 = get(_dataprod_pars_p_psd(data, sel, detector).aoecut, :hi, NaN)   
-    ClosedInterval(aoecut_lo, aoecut_hi) 
+function dataprod_pars_aoe_window(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
+    aoecut_lo::Float64 = get(_dataprod_pars_p_psd(data, sel, detector).cut, :lowcut, NaN)
+    aoecut_hi::Float64 = get(_dataprod_pars_p_psd(data, sel, detector).cut, :highcut, NaN)   
+    ClosedInterval(aoecut_lo, aoecut_hi)
 end
 
 
 
-const _cached_get_larcal_props = LRU{Tuple{UInt, ValiditySelection}, Union{PropDict,PropDicts.MissingProperty}}(maxsize = 10^3)
+const _cached_get_larcal_props = LRU{Tuple{UInt, AnyValiditySelection}, Union{PropDict,PropDicts.MissingProperty}}(maxsize = 10^3)
 
-function _get_larcal_props(data::LegendData, sel::ValiditySelection)
+function _get_larcal_props(data::LegendData, sel::AnyValiditySelection)
     key = (objectid(data), sel)
     get!(_cached_get_larcal_props, key) do
-        dataprod_parameters(data).phy.p_sipm(sel)
+        get_values(dataprod_parameters(data).ppars.sipm(sel))
     end
 end
 
-function _get_larcal_props(data::LegendData, sel::ValiditySelection, detector::DetectorId)
+function _get_larcal_props(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
     _get_larcal_props(data, sel)[Symbol(detector)]
 end
 
 
 """
-    get_spm_cal_propfunc(data::LegendData, sel::ValiditySelection, detector::DetectorId)
+    get_spm_cal_propfunc(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
 
 Get the LAr/SPMS calibration function for the given data, validity selection
 and detector.
 """
-function get_spm_cal_propfunc(data::LegendData, sel::ValiditySelection, detector::DetectorId)
+function get_spm_cal_propfunc(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
     larcal_props = _get_larcal_props(data, sel, detector)
 
     a::Float64 = get(larcal_props, :a, NaN)
@@ -336,12 +347,12 @@ export get_spm_cal_propfunc
 
 
 """
-    get_pulser_cal_propfunc(data::LegendData, sel::ValiditySelection, detector::DetectorId)
+    get_pulser_cal_propfunc(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
 
 Get the pulser calibration function for the given data, validity selection
 and the pulser channel referred to by `detector`.
 """
-function get_pulser_cal_propfunc(data::LegendData, sel::ValiditySelection, detector::DetectorId)
+function get_pulser_cal_propfunc(data::LegendData, sel::AnyValiditySelection, detector::DetectorId)
     # ToDo: Make pulser threashold configurable:
     let pulser_threshold = 100
         @pf (

--- a/src/dataprod_config.jl
+++ b/src/dataprod_config.jl
@@ -46,7 +46,7 @@ dataprod_config(l200)
 ```
 """
 function dataprod_parameters(data::LegendData)
-    data.jlpar
+    data.par
 end
 export dataprod_parameters
 

--- a/src/filekey.jl
+++ b/src/filekey.jl
@@ -15,6 +15,10 @@ Base.getindex(p::PropDicts.PropDict, datasel::DataSelector) = p[Symbol(datasel)]
 Base.setindex!(p::PropDict, value, datasel::DataSelector) = setindex!(p, value, Symbol(datasel))
 Base.haskey(p::PropDicts.PropDict, datasel::DataSelector) = haskey(p, Symbol(datasel))
 
+_markdown_cell_content(@nospecialize(content::DataSelector)) = string(content)
+lreport!(rpt::LegendReport, @nospecialize(sel::DataSelector)) = lreport!(rpt, string(sel))
+
+
 """
     struct ExpSetup <: DataSelector
 

--- a/src/legend_report.jl
+++ b/src/legend_report.jl
@@ -168,6 +168,9 @@ function lreport!(rpt::LegendReport, @nospecialize(markdown_str::AbstractString)
     lreport!(rpt, Markdown.parse(markdown_str))
 end
 
+lreport!(rpt::LegendReport, @nospecialize(number::AbstractFloat)) = lreport!(rpt, string(round(number, digits=3)))
+lreport!(rpt::LegendReport, @nospecialize(number::Quantity{<:Real})) = lreport!(rpt, string(round(unit(number), number, digits=3)))
+
 
 """
     LegendDataManagement.lreport_for_show!(rpt::LegendReport, mime::MIME, content)
@@ -220,6 +223,7 @@ _markdown_cell_content(@nospecialize(content::Expr)) = string(content)
 _markdown_cell_content(@nospecialize(content::Number)) = _show_plain_compact(content)
 _markdown_cell_content(@nospecialize(content::AbstractInterval)) = _show_plain_compact(content)
 _markdown_cell_content(@nospecialize(content::Array)) = _show_plain_compact(content)
+
 
 _show_plain_compact(@nospecialize(content)) = sprint(show, content; context = :compact=>true)
 


### PR DESCRIPTION
Bug Fixes:
- `DataSelectors` support `get`
- `lprops` can handle `NaN`

Improved calibration functions:
- Updated routines to adapt to new `pars` to be able to read units and errors and handle the new `pars` structure