### PR TITLE
Fixes in `ChannelId` parsing

### DIFF
--- a/src/filekey.jl
+++ b/src/filekey.jl
@@ -623,9 +623,9 @@ ChannelId("ch1083204") == ch
 struct ChannelId <: DataSelector
     no::Int
     function ChannelId(no::Int)
-        m = match(ch_expr, "ch$(no)")
+        m = match(ch_expr, "ch$(lpad(no, no < 1000 ? 3 : 7, '0'))")
         if (m == nothing)
-            throw(ArgumentError("\"$no\" does not look like a valid file LEGEND data channel name"))
+            throw(ArgumentError("\"$(no)\" does not look like a valid file LEGEND data channel name"))
         end
         new(no)
     end
@@ -641,14 +641,15 @@ function Base.print(io::IO, ch::ChannelId)
     if ch.no < 1000
         @printf(io, "ch%03d", ch.no)
     else
-        @printf(io, "ch%03d", ch.no)
+        @printf(io, "ch%07d", ch.no)
     end
 end
 
-const ch_expr = r"^ch([0-9]{3}|[0-9]{7})$"
+# In 7-digit numbers, the first two numbers cannot be BOTH zero
+const ch_expr = r"^ch([0-9]{3}|(?:0[1-9]|[1-9][0-9])[0-9]{5})$"
 
 _can_convert_to(::Type{ChannelId}, s::AbstractString) = !isnothing(match(ch_expr, s))
-_can_convert_to(::Type{ChannelId}, s::Int) = _can_convert_to(ChannelId, "ch$s")
+_can_convert_to(::Type{ChannelId}, s::Int) = _can_convert_to(ChannelId, lpad(0, no < 1000 ? 3 : 7, '0'))
 _can_convert_to(::Type{ChannelId}, s::ChannelId) = true
 _can_convert_to(::Type{ChannelId}, s) = false
 


### PR DESCRIPTION
This PR addresses the changes in commit 57c3eb1b96c5034d020013bedb60b93bdff0db29.

Seems like there are two kinds of `ChannelIds`: one with three digits (old) and one with seven digits (new).
The implementation of how to check the validity of a `ChannelId` seemed a bit buggy.
I tried to fix it but would need some feedback from people who have worked with `ChannelIds` more.

My understanding:
- a 3-digit `ChannelId` can be anything from 0 (or 1?) to 999.
- a 7-digit `ChannelId` cannot have the first two digits being BOTH 0, otherwise they can be whatever.

If this is true, I updated the regular expression `ch_expr`.
I also updated the code to add leading zeros to `Integers` before being checked for validity.

This might prevent the current tests from failing.
