### PR TITLE
Active and total volume calculation

### DIFF
--- a/.github/workflows/CompatHelper.yml
+++ b/.github/workflows/CompatHelper.yml
@@ -15,7 +15,7 @@ jobs:
         run: which julia
         continue-on-error: true
       - name: Install Julia, but only if it is not already available in the PATH
-        uses: julia-actions/setup-julia@v1
+        uses: julia-actions/setup-julia@v2
         with:
           version: '1'
           arch: ${{ runner.arch }}

--- a/.github/workflows/DocPreviewCleanup.yml
+++ b/.github/workflows/DocPreviewCleanup.yml
@@ -1,0 +1,33 @@
+name: Doc Preview Cleanup
+
+on:
+  pull_request:
+    types: [closed]
+
+# Ensure that only one "Doc Preview Cleanup" workflow is force pushing at a time
+concurrency:
+  group: doc-preview-cleanup
+  cancel-in-progress: false
+
+jobs:
+  doc-preview-cleanup:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: write
+    steps:
+      - name: Checkout gh-pages branch
+        uses: actions/checkout@v4
+        with:
+          ref: gh-pages
+      - name: Delete preview and history + push changes
+        run: |
+          if [ -d "${preview_dir}" ]; then
+              git config user.name "Documenter.jl"
+              git config user.email "documenter@juliadocs.github.io"
+              git rm -rf "${preview_dir}"
+              git commit -m "delete preview"
+              git branch gh-pages-new $(echo "delete history" | git commit-tree HEAD^{tree})
+              git push --force origin gh-pages-new:gh-pages
+          fi
+        env:
+          preview_dir: previews/PR${{ github.event.number }}

--- a/.github/workflows/TagBot.yml
+++ b/.github/workflows/TagBot.yml
@@ -8,18 +8,7 @@ on:
       lookback:
         default: 3
 permissions:
-  actions: read
-  checks: read
   contents: write
-  deployments: read
-  issues: read
-  discussions: read
-  packages: read
-  pages: read
-  pull-requests: read
-  repository-projects: read
-  security-events: read
-  statuses: read
 jobs:
   TagBot:
     if: github.event_name == 'workflow_dispatch' || github.actor == 'JuliaTagBot'
@@ -28,6 +17,4 @@ jobs:
       - uses: JuliaRegistries/TagBot@v1
         with:
           token: ${{ secrets.GITHUB_TOKEN }}
-          # Edit the following line to reflect the actual name of the GitHub Secret containing your private key
           ssh: ${{ secrets.DOCUMENTER_KEY }}
-          # ssh: ${{ secrets.NAME_OF_MY_SSH_PRIVATE_KEY_SECRET }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -25,9 +25,9 @@ jobs:
       fail-fast: false
       matrix:
         version:
-          - '1.9'
+          - '1.10'
           - '1'
-          - 'nightly'
+          - 'pre'
         os:
           - ubuntu-latest
         arch:
@@ -44,11 +44,11 @@ jobs:
             arch: x64
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: ${{ matrix.version }}
           arch: ${{ matrix.arch }}
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - name: registry_add
         run: julia add_registries.jl
       - uses: julia-actions/julia-buildpkg@v1
@@ -68,10 +68,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
-      - uses: julia-actions/setup-julia@v1
+      - uses: julia-actions/setup-julia@v2
         with:
           version: '1'
-      - uses: julia-actions/cache@v1
+      - uses: julia-actions/cache@v2
       - name: registry_add
         run: julia add_registries.jl
       - uses: julia-actions/julia-buildpkg@v1

--- a/Project.toml
+++ b/Project.toml
@@ -1,6 +1,6 @@
 name = "LegendDataManagement"
 uuid = "9feedd95-f0e0-423f-a8dc-de0970eae6b3"
-version = "0.3.1"
+version = "0.3.2"
 
 [deps]
 Dates = "ade2ca70-3891-5945-98fb-dc099432e06a"
@@ -71,4 +71,4 @@ Tables = "0.2, 1.0"
 TypedTables = "1.4"
 UUIDs = "1"
 Unitful = "1"
-julia = "1.9"
+julia = "1.10"

--- a/src/LegendDataManagement.jl
+++ b/src/LegendDataManagement.jl
@@ -49,6 +49,7 @@ include("calibration_functions.jl")
 include("evt_functions.jl")
 include("lprops.jl")
 include("data_io.jl")
+include("active_volume.jl")
 include("utils/utils.jl")
 
 end # module

--- a/src/active_volume.jl
+++ b/src/active_volume.jl
@@ -60,8 +60,8 @@ function get_active_volume(pd::PropDict, ::Val{:bege}, fccd::T = .0) where {T <:
     x = h * tan(α)
     taper_bottom_volume = iszero(x) ? zero(T) : get_outer_taper_volume(x, h * R / x, h, R)
     
-    return  π * R^2 * H - (groove_volume + taper_top_volume + taper_bottom_volume) +
-            π * g.groove.radius_in_mm.outer^2 * fccd - get_extra_volume(g, fccd)
+    return (π * R^2 * H - (groove_volume + taper_top_volume + taper_bottom_volume) +
+            π * g.groove.radius_in_mm.outer^2 * fccd - get_extra_volume(g, fccd)) * 1e-3u"cm^3"
 end
 
 function get_active_volume(pd::PropDict, ::Val{:icpc}, fccd::T = .0) where {T <: AbstractFloat}
@@ -97,9 +97,9 @@ function get_active_volume(pd::PropDict, ::Val{:icpc}, fccd::T = .0) where {T <:
     x = h * tan(α)
     taper_borehole_volume = iszero(x) ? zero(T) : get_inner_taper_volume(x, h * (rb + x) / x, h, rb + x)
     
-    return  π * R^2 * H - (groove_volume + borehole_volume) - 
+    return (π * R^2 * H - (groove_volume + borehole_volume) - 
             taper_top_volume + taper_bottom_volume + taper_borehole_volume +
-            π * g.groove.radius_in_mm.outer^2 * fccd - get_extra_volume(g, fccd)
+            π * g.groove.radius_in_mm.outer^2 * fccd - get_extra_volume(g, fccd)) * 1e-3u"cm^3"
 end
 
 function get_active_volume(pd::PropDict, ::Val{:coax}, fccd::T = .0) where {T <: AbstractFloat}
@@ -129,8 +129,8 @@ function get_active_volume(pd::PropDict, ::Val{:coax}, fccd::T = .0) where {T <:
     x = h * tan(α)
     taper_bottom_volume = iszero(x) ? zero(T) : get_outer_taper_volume(x, h * R / x, h, R)
         
-    return  π * R^2 * H - (taper_top_volume + taper_bottom_volume + groove_volume + borehole_volume) + 
-            π * g.groove.radius_in_mm.outer^2 * fccd - get_extra_volume(g, fccd)
+    return (π * R^2 * H - (taper_top_volume + taper_bottom_volume + groove_volume + borehole_volume) + 
+            π * g.groove.radius_in_mm.outer^2 * fccd - get_extra_volume(g, fccd)) * 1e-3u"cm^3"
 end
 
 
@@ -153,8 +153,8 @@ function get_active_volume(pd::PropDict, ::Val{:ppc}, fccd::T = .0) where {T <: 
     x = h * tan(α)
     taper_bottom_volume = iszero(x) ? zero(T) : get_outer_taper_volume(x, h * R / x, h, R)
     
-    return  π * R^2 * H - (taper_top_volume + taper_bottom_volume) +
-            π * g.pp_contact.radius_in_mm^2 * fccd - get_extra_volume(g, fccd)
+    return (π * R^2 * H - (taper_top_volume + taper_bottom_volume) +
+            π * g.pp_contact.radius_in_mm^2 * fccd - get_extra_volume(g, fccd)) * 1e-3u"cm^3"
 end
 
 function get_active_volume(pd::PropDict, fccd::AbstractFloat)

--- a/src/active_volume.jl
+++ b/src/active_volume.jl
@@ -1,0 +1,162 @@
+# This file is a part of LegendDataManagement.jl, licensed under the MIT License (MIT).
+
+# These are function needed to calculate the active volume based on 
+# LEGEND detector metadata and measured dead layer thicknesses
+
+
+@inline get_inner_taper_volume(x, y, h, r) = π * (r^2 * y / 3 - (r - x)^2 * (y + 2h) / 3)
+@inline get_outer_taper_volume(x, y, h, r) = π * (r^2 * h - (r - x)^2 * h) - get_inner_taper_volume(x, y, h, r)
+
+function get_extra_volume(geometry::PropDict, ::Val{:crack}, fccd::T) where {T <: AbstractFloat}
+    @warn "Active volume calculations for detectors with cracks are not implemented yet"
+    return zero(T)
+end
+
+function get_extra_volume(geometry::PropDict, ::Val{:topgroove}, fccd::AbstractFloat)
+    r = geometry.extra.topgroove.radius_in_mm
+    d = geometry.extra.topgroove.depth_in_mm
+    return π * r^2 * d
+end
+
+function get_extra_volume(geometry::PropDict, ::Val{:bottom_cylinder}, fccd::AbstractFloat)
+    r = geometry.extra.bottom_cylinder.radius_in_mm - fccd
+    h = geometry.extra.bottom_cylinder.height_in_mm - fccd
+    t = geometry.extra.bottom_cylinder.transition_in_mm
+    R = geometry.radius_in_mm - fccd
+    return get_outer_taper_volume(R - r, t * R / (R - r), t, R) + π * h * (R^2 - r^2)
+end
+
+function get_extra_volume(geometry::PropDict, fccd::T = .0) where {T <: AbstractFloat}
+    if isa(geometry.extra, PropDicts.MissingProperty)
+        return zero(T)
+    else
+        return get_extra_volume(geometry, Val(first(keys(geometry.extra))), fccd)
+    end
+end
+
+# @inline get_mass(volume::U, enrichment::V) where {U <: AbstractFloat, V <: AbstractFloat} = 
+#     volume / 1000 * (5.327 * enrichment * 76/72 + 5.327 * (1 - enrichment))
+
+# Detector specific active volume calculation
+function get_active_volume(pd::PropDict, ::Val{:bege}, fccd::T = .0) where {T <: AbstractFloat}
+
+    g = pd.geometry
+    
+    R = g.radius_in_mm - fccd
+    H = g.height_in_mm - 2 * fccd
+
+    # Groove
+    groove_volume = π * g.groove.depth_in_mm * (g.groove.radius_in_mm.outer^2 - g.groove.radius_in_mm.inner^2)
+    
+    # Top taper
+    h = g.taper.top.height_in_mm
+    α = g.taper.top.angle_in_deg / 360 * 2π
+    x = h * tan(α)
+    taper_top_volume = iszero(x) ? zero(T) : get_outer_taper_volume(x, h * R / x, h, R)
+    
+    # Bottom taper
+    h = g.taper.bottom.height_in_mm
+    α = g.taper.bottom.angle_in_deg / 360 * 2π
+    x = h * tan(α)
+    taper_bottom_volume = iszero(x) ? zero(T) : get_outer_taper_volume(x, h * R / x, h, R)
+    
+    return  π * R^2 * H - (groove_volume + taper_top_volume + taper_bottom_volume) +
+            π * g.groove.radius_in_mm.outer^2 * fccd - get_extra_volume(g, fccd)
+end
+
+function get_active_volume(pd::PropDict, ::Val{:icpc}, fccd::T = .0) where {T <: AbstractFloat}
+
+    g = pd.geometry
+    
+    R = g.radius_in_mm - fccd
+    H = g.height_in_mm - 2 * fccd
+    
+    # Borehole
+    rb = g.borehole.radius_in_mm + fccd
+    db = g.borehole.depth_in_mm
+    borehole_volume = π * rb^2 * db
+    
+    # Groove
+    groove_volume = π * g.groove.depth_in_mm * (g.groove.radius_in_mm.outer^2 - g.groove.radius_in_mm.inner^2)
+
+    # Top taper
+    h = g.taper.top.height_in_mm
+    α = g.taper.top.angle_in_deg / 360 * 2π
+    x = h * tan(α)
+    taper_top_volume = iszero(x) ? zero(T) : get_outer_taper_volume(x, h * R / x, h, R)
+    
+    # Bottom taper
+    h = g.taper.bottom.height_in_mm
+    α = g.taper.bottom.angle_in_deg / 360 * 2π
+    x = h * tan(α)
+    taper_bottom_volume = iszero(x) ? zero(T) : get_outer_taper_volume(x, h * R / x, h, R)
+    
+    # Borehole taper
+    h = g.taper.bottom.height_in_mm
+    α = g.taper.bottom.angle_in_deg / 360 * 2π
+    x = h * tan(α)
+    taper_borehole_volume = iszero(x) ? zero(T) : get_inner_taper_volume(x, h * (rb + x) / x, h, rb + x)
+    
+    return  π * R^2 * H - (groove_volume + borehole_volume) - 
+            taper_top_volume + taper_bottom_volume + taper_borehole_volume +
+            π * g.groove.radius_in_mm.outer^2 * fccd - get_extra_volume(g, fccd)
+end
+
+function get_active_volume(pd::PropDict, ::Val{:coax}, fccd::T = .0) where {T <: AbstractFloat}
+    
+    g = pd.geometry
+    
+    R = g.radius_in_mm - fccd
+    H = g.height_in_mm - 2 * fccd
+    
+    # Borehole
+    rb = g.borehole.radius_in_mm
+    db = g.borehole.depth_in_mm
+    borehole_volume = π * rb^2 * db
+    
+    # Groove
+    groove_volume = π * g.groove.depth_in_mm * (g.groove.radius_in_mm.outer^2 - g.groove.radius_in_mm.inner^2)
+    
+    # Top taper
+    h = g.taper.top.height_in_mm
+    α = g.taper.top.angle_in_deg / 360 * 2π
+    x = h * tan(α)
+    taper_top_volume = iszero(x) ? zero(T) : get_outer_taper_volume(x, h * R / x, h, R)    
+    
+    # Bottom taper
+    h = g.taper.bottom.height_in_mm
+    α = g.taper.bottom.angle_in_deg / 360 * 2π
+    x = h * tan(α)
+    taper_bottom_volume = iszero(x) ? zero(T) : get_outer_taper_volume(x, h * R / x, h, R)
+        
+    return  π * R^2 * H - (taper_top_volume + taper_bottom_volume + groove_volume + borehole_volume) + 
+            π * g.groove.radius_in_mm.outer^2 * fccd - get_extra_volume(g, fccd)
+end
+
+
+function get_active_volume(pd::PropDict, ::Val{:ppc}, fccd::T = .0) where {T <: AbstractFloat}
+    
+    g = pd.geometry
+    
+    R = g.radius_in_mm - fccd
+    H = g.height_in_mm - 2 * fccd
+    
+    # Top taper
+    h = g.taper.top.height_in_mm
+    α = g.taper.top.angle_in_deg / 360 * 2π
+    x = h * tan(α)
+    taper_top_volume = iszero(x) ? zero(T) : get_outer_taper_volume(x, h * R / x, h, R)
+    
+    # Bottom taper
+    h = g.taper.bottom.height_in_mm
+    α = g.taper.bottom.angle_in_deg / 360 * 2π
+    x = h * tan(α)
+    taper_bottom_volume = iszero(x) ? zero(T) : get_outer_taper_volume(x, h * R / x, h, R)
+    
+    return  π * R^2 * H - (taper_top_volume + taper_bottom_volume) +
+            π * g.pp_contact.radius_in_mm^2 * fccd - get_extra_volume(g, fccd)
+end
+
+function get_active_volume(pd::PropDict, fccd::AbstractFloat)
+    get_active_volume(pd, Val(Symbol(pd.type)), fccd)
+end

--- a/src/legend_data.jl
+++ b/src/legend_data.jl
@@ -238,7 +238,7 @@ const _cached_channelinfo = LRU{Tuple{UInt, AnyValiditySelection}, StructVector}
 Get all channel information for the given [`LegendData`](@ref) and
 [`ValiditySelection`](@ref).
 """
-function channelinfo(data::LegendData, sel::AnyValiditySelection; system::Symbol = :all, only_processable::Bool = false, detailed::Bool = false)
+function channelinfo(data::LegendData, sel::AnyValiditySelection; system::Symbol = :all, only_processable::Bool = false, extended::Bool = false)
     key = (objectid(data), sel)
     chinfo = get!(_cached_channelinfo, key) do
         chmap = data.metadata(sel).hardware.configuration.channelmaps
@@ -296,7 +296,7 @@ function channelinfo(data::LegendData, sel::AnyValiditySelection; system::Symbol
                 location, detstring, fiber, position
             )
 
-            if detailed
+            if extended
                 cc4::StaticString{8} = get(chmap[k].electronics.cc4, :id, "")
                 cc4ch::Int = get(chmap[k].electronics.cc4, :channel, -1)
                 daqcrate::Int = get(chmap[k].daq, :crate, -1)

--- a/src/legend_data.jl
+++ b/src/legend_data.jl
@@ -272,14 +272,13 @@ function channelinfo(data::LegendData, sel::AnyValiditySelection; system::Symbol
         end
 
         function make_row(k::Symbol)
+
             fcid::Int = get(chmap[k].daq, :fcid, -1)
             rawid::Int = chmap[k].daq.rawid
             channel::ChannelId = ChannelId(rawid)
 
             detector::DetectorId = DetectorId(k)
             det_type::Symbol = Symbol(ifelse(haskey(diodmap, k), diodmap[k].type, :unknown))
-            enrichment::Unitful.Quantity{<:Measurement{<:Float64}} = if haskey(diodmap, k) && haskey(diodmap[k].production, :enrichment) measurement(diodmap[k].production.enrichment.val, diodmap[k].production.enrichment.unc) else measurement(Float64(NaN), Float64(NaN)) end *100u"percent"
-            mass::Unitful.Mass{<:Float64} = if haskey(diodmap, k) && haskey(diodmap[k].production, :mass_in_g) diodmap[k].production.mass_in_g else Float64(NaN) end *1e-3*u"kg"
             local system::Symbol = Symbol(chmap[k].system)
             processable::Bool = get(dpcfg[k], :processable, false)
             usability::Symbol = Symbol(get(dpcfg[k], :usability, :unknown))
@@ -292,19 +291,22 @@ function channelinfo(data::LegendData, sel::AnyValiditySelection; system::Symbol
 
             location::Symbol, detstring::Int, position::Int, fiber::StaticString{8} = _convert_location(chmap[k].location)
 
-            cc4::StaticString{8} = get(chmap[k].electronics.cc4, :id, "")
-            cc4ch::Int = get(chmap[k].electronics.cc4, :channel, -1)
-            daqcrate::Int = get(chmap[k].daq, :crate, -1)
-            daqcard::Int = chmap[k].daq.card.id
-            hvcard::Int = get(chmap[k].voltage.card, :id, -1)
-            hvch::Int = get(chmap[k].voltage, :channel, -1)
-
             c = (;
                 detector, channel, fcid, rawid, system, processable, usability, is_blinded, low_aoe_status, high_aoe_status, lq_status, batch5_dt_cut, is_bb_like, det_type,
-                location, detstring, fiber, position, cc4, cc4ch, daqcrate, daqcard, hvcard, hvch, enrichment, mass
+                location, detstring, fiber, position
             )
 
             if detailed
+                cc4::StaticString{8} = get(chmap[k].electronics.cc4, :id, "")
+                cc4ch::Int = get(chmap[k].electronics.cc4, :channel, -1)
+                daqcrate::Int = get(chmap[k].daq, :crate, -1)
+                daqcard::Int = chmap[k].daq.card.id
+                hvcard::Int = get(chmap[k].voltage.card, :id, -1)
+                hvch::Int = get(chmap[k].voltage, :channel, -1)
+
+                enrichment::Unitful.Quantity{<:Measurement{<:Float64}} = if haskey(diodmap, k) && haskey(diodmap[k].production, :enrichment) measurement(diodmap[k].production.enrichment.val, diodmap[k].production.enrichment.unc) else measurement(Float64(NaN), Float64(NaN)) end *100u"percent"
+                mass::Unitful.Mass{<:Float64} = if haskey(diodmap, k) && haskey(diodmap[k].production, :mass_in_g) diodmap[k].production.mass_in_g else Float64(NaN) end *1e-3*u"kg"
+            
                 total_volume::Unitful.Volume{<:Float64} = if haskey(diodmap, k) get_active_volume(diodmap[k], 0.0) else Float64(NaN) end * 1e-3u"cm^3"
                 fccds = diodmap[k].characterization.l200_site.fccd_in_mm
                 fccd::Float64 = if isa(fccds, NoSuchPropsDBEntry) || 
@@ -317,7 +319,7 @@ function channelinfo(data::LegendData, sel::AnyValiditySelection; system::Symbol
                     fccds[first(keys(fccds))].value
                 end
                 active_volume::Unitful.Volume{<:Float64} = if haskey(diodmap, k) get_active_volume(diodmap[k], 0.0) else Float64(NaN) end * 1e-3u"cm^3"
-                c = merge(c, (; total_volume, active_volume))
+                c = merge(c, (; cc4, cc4ch, daqcrate, daqcard, hvcard, hvch, enrichment, mass, total_volume, active_volume))
             end
             
             c

--- a/src/legend_data.jl
+++ b/src/legend_data.jl
@@ -307,7 +307,7 @@ function channelinfo(data::LegendData, sel::AnyValiditySelection; system::Symbol
                 enrichment::Unitful.Quantity{<:Measurement{<:Float64}} = if haskey(diodmap, k) && haskey(diodmap[k].production, :enrichment) measurement(diodmap[k].production.enrichment.val, diodmap[k].production.enrichment.unc) else measurement(Float64(NaN), Float64(NaN)) end *100u"percent"
                 mass::Unitful.Mass{<:Float64} = if haskey(diodmap, k) && haskey(diodmap[k].production, :mass_in_g) diodmap[k].production.mass_in_g else Float64(NaN) end *1e-3*u"kg"
             
-                total_volume::Unitful.Volume{<:Float64} = if haskey(diodmap, k) get_active_volume(diodmap[k], 0.0) else Float64(NaN) end * 1e-3u"cm^3"
+                total_volume::Unitful.Volume{<:Float64} = if haskey(diodmap, k) get_active_volume(diodmap[k], 0.0) else Float64(NaN) * u"cm^3" end
                 fccds = diodmap[k].characterization.l200_site.fccd_in_mm
                 fccd::Float64 = if isa(fccds, NoSuchPropsDBEntry) || 
                                    isa(fccds, PropDicts.MissingProperty) || 
@@ -318,7 +318,7 @@ function channelinfo(data::LegendData, sel::AnyValiditySelection; system::Symbol
                 else 
                     fccds[first(keys(fccds))].value
                 end
-                active_volume::Unitful.Volume{<:Float64} = if haskey(diodmap, k) get_active_volume(diodmap[k], 0.0) else Float64(NaN) end * 1e-3u"cm^3"
+                active_volume::Unitful.Volume{<:Float64} = if haskey(diodmap, k) get_active_volume(diodmap[k], 0.0) else Float64(NaN) * u"cm^3" end
                 c = merge(c, (; cc4, cc4ch, daqcrate, daqcard, hvcard, hvch, enrichment, mass, total_volume, active_volume))
             end
             

--- a/test/test_ext_ssd.jl
+++ b/test/test_ext_ssd.jl
@@ -2,12 +2,91 @@
 
 using LegendDataManagement
 using Test
-
-using SolidStateDetectors:SolidStateDetector
+using SolidStateDetectors
 
 include("testing_utils.jl")
 
+function SolidStateDetectors.Simulation(l200, detname; medium::Union{String, Symbol} = "vacuum")
+
+    config_dict = Dict()
+    radius = l200.metadata.hardware.detectors.germanium.diodes[Symbol(detname)].geometry.radius_in_mm / 1000
+    height = l200.metadata.hardware.detectors.germanium.diodes[Symbol(detname)].geometry.height_in_mm / 1000
+    det = SolidStateDetector(l200, detname);
+
+    function get_material_name(material::NamedTuple)
+        collect(keys(SolidStateDetectors.material_properties))[findfirst(getindex.(values(SolidStateDetectors.material_properties), :name) .== material.name)]
+    end
+        
+    config_dict["name"] = "$(detname)"
+    config_dict["units"] = Dict(
+        "length" => "m",
+        "angle" => "deg",
+        "potential" => "V",
+        "temperature" => "K"
+    )
+    config_dict["grid"] = Dict(
+        "coordinates" => "cylindrical",
+        "axes" => Dict(
+            "r" => Dict(
+                "to" => "$(radius + 0.01)",
+                "boundaries" => "inf"
+            ),
+            "phi" => Dict(
+                "from" => 0,
+                "to" => 0,
+                "boundaries" => "periodic"
+            ),
+            "z" => Dict(
+                "from" => "-0.01",
+                "to" => "$(height + 0.01)",
+                "boundaries" => Dict(
+                    "left" => "inf",
+                    "right" => "inf"
+                )
+            )
+        )
+    )
+    config_dict["medium"] = medium
+    config_dict["detectors"] = [
+        Dict(
+            "semiconductor" => Dict(
+                "material" => "$(get_material_name(det.semiconductor.material))",
+                "temperature" => det.semiconductor.temperature,
+                "geometry" => SolidStateDetectors.ConstructiveSolidGeometry.Dictionary(det.semiconductor.geometry)
+                # charge_drift_model ?
+                # impurity_density ?
+            ),
+            "contacts" => [
+                Dict(
+                    "material" => "$(get_material_name(c.material))",
+                    "id" => c.id,
+                    "potential" => c.potential,
+                    "geometry" => SolidStateDetectors.ConstructiveSolidGeometry.Dictionary(c.geometry)
+                )
+                for c in det.contacts
+            ]
+        ) 
+    ]
+    T = SolidStateDetectors.get_precision_type(det)
+    Simulation{T}(config_dict)
+end
+
 @testset "test_ext_ssd" begin
     l200 = LegendData(:l200)
-    @test SolidStateDetector(l200, :V99000A) isa SolidStateDetector
+    for detname in (:V99000A, :B99000A, :C99000A, :P99000A)
+        @testset "$(detname)" begin
+            det = SolidStateDetector(l200, detname) 
+            @test det isa SolidStateDetector
+            sim = Simulation(l200, detname)
+            @test sim isa Simulation
+
+            # Compare active volume from SSD to active volume from LegendDataManagement
+            sim.detector = SolidStateDetector(sim.detector, contact_id = 1, contact_potential = 0) # Set potential to 0V to avoid long simulation times
+            sim.detector = SolidStateDetector(sim.detector, contact_id = 2, contact_potential = 0) # (we just need the PointTypes for the active volume)
+            calculate_electric_potential!(sim, max_tick_distance = 0.1u"mm", refinement_limits = missing, verbose = false)
+            active_volume_ssd = SolidStateDetectors.get_active_volume(sim.point_types)
+            active_volume_ldm = LegendDataManagement.get_active_volume(l200.metadata.hardware.detectors.germanium.diodes[Symbol(detname)], 0.0)
+            @test isapprox(active_volume_ssd, active_volume_ldm, rtol = 0.01)
+        end
+    end
 end

--- a/test/test_legend_data.jl
+++ b/test/test_legend_data.jl
@@ -33,7 +33,7 @@ include("testing_utils.jl")
     empty!(LegendDataManagement._cached_channelinfo)
 
     # Test the extended channel info with active volume calculation
-    extended = channelinfo(l200, filekey, detailed = true)
+    extended = channelinfo(l200, filekey, extended = true)
     @test extended isa TypedTables.Table
     @test :active_volume in columnnames(extended)
 

--- a/test/test_legend_data.jl
+++ b/test/test_legend_data.jl
@@ -35,7 +35,11 @@ include("testing_utils.jl")
     # Test the extended channel info with active volume calculation
     extended = channelinfo(l200, filekey, extended = true)
     @test extended isa TypedTables.Table
-    @test :active_volume in columnnames(extended)
+
+    # Check that some keywords only appear in the extended channelinfo
+    extended_keywords = (:cc4, :cc4ch, :daqcrate, :daqcard, :hvcard, :hvch, :enrichment, :mass, :total_volume, :active_volume)
+    @test !any(in(columnnames(chinfo)),   extended_keywords)
+    @test  all(in(columnnames(extended)), extended_keywords)
 
     # ToDo: Make type-stable:
     # @test #=@inferred=#(channel_info(l200, filekey)) isa StructArray

--- a/test/test_legend_data.jl
+++ b/test/test_legend_data.jl
@@ -24,10 +24,18 @@ include("testing_utils.jl")
     @test l200.metadata == LegendDataManagement.AnyProps(props_base_path)
 
     # ToDo: Make type-stable:
-    @test (channelinfo(l200, filekey)) isa TypedTables.Table
+    @test channelinfo(l200, filekey) isa TypedTables.Table
     chinfo = channelinfo(l200, filekey)
     @test all(filterby(@pf $processable && $usability == :on)(chinfo).processable)
     @test all(filterby(@pf $processable && $usability == :on)(chinfo).usability .== :on)
+
+    # Delete the channelinfo cache
+    empty!(LegendDataManagement._cached_channelinfo)
+
+    # Test the extended channel info with active volume calculation
+    extended = channelinfo(l200, filekey, detailed = true)
+    @test extended isa TypedTables.Table
+    @test :active_volume in columnnames(extended)
 
     # ToDo: Make type-stable:
     # @test #=@inferred=#(channel_info(l200, filekey)) isa StructArray


### PR DESCRIPTION
`channelinfo` now has a new keyword: `detailed` (can also be renamed to something else) with default value `false`.

If set to `true`, the function `channelinfo` will calculate the total volume and the active volume of all `:geds` based on the FCCD values provided in the metadata and adds them as columns to the output of `channelinfo`.

There are warnings for:
- detectors with `cracks` in the metadata (the functions to calculate their volumes are still missing)
- detectors with no FCCD values provided (there, the active volume is equal to the total volume)
