### PR TITLE
Implement active volume calculation for cracks

### DIFF
--- a/src/active_volume.jl
+++ b/src/active_volume.jl
@@ -8,10 +8,10 @@
 @inline get_outer_taper_volume(x, y, h, r) = π * (r^2 * h - (r - x)^2 * h) - get_inner_taper_volume(x, y, h, r)
 
 function get_extra_volume(geometry::PropDict, ::Val{:crack}, fccd::T) where {T <: AbstractFloat}
-    r = geometry.radius_in_mm
-    H = geometry.height_in_mm
-    p0 = geometry.extra.crack.radius_in_mm
+    r = geometry.radius_in_mm - fccd
+    H = geometry.height_in_mm - 2*fccd
     alpha = geometry.extra.crack.angle_in_deg
+    p0 = geometry.extra.crack.radius_in_mm + fccd * (secd(alpha) - tand(alpha) - 1)
     return if iszero(alpha)
         # Vertical crack
         (r^2 * acos(1 - p0/r) - sqrt(2r*p0 - p0^2) * (r - p0)) * H

--- a/src/active_volume.jl
+++ b/src/active_volume.jl
@@ -8,6 +8,8 @@
 @inline get_outer_taper_volume(x, y, h, r) = π * (r^2 * h - (r - x)^2 * h) - get_inner_taper_volume(x, y, h, r)
 
 function get_extra_volume(geometry::PropDict, ::Val{:crack}, fccd::T) where {T <: AbstractFloat}
+    # Find a picture of the definition of crack here:
+    # https://github.com/legend-exp/legend-metadata/blob/archived/hardware/detectors/detector-metadata_5.pdf
     r = geometry.radius_in_mm - fccd
     H = geometry.height_in_mm - 2*fccd
     alpha = geometry.extra.crack.angle_in_deg
@@ -25,12 +27,19 @@ function get_extra_volume(geometry::PropDict, ::Val{:crack}, fccd::T) where {T <
 end
 
 function get_extra_volume(geometry::PropDict, ::Val{:topgroove}, fccd::AbstractFloat)
-    r = geometry.extra.topgroove.radius_in_mm
-    d = geometry.extra.topgroove.depth_in_mm
-    return π * r^2 * d
+    # Find a picture of the definition of topgroove here:
+    # https://github.com/legend-exp/legend-metadata/blob/archived/hardware/detectors/detector-metadata_4.pdf
+    rb = geometry.borehole.radius_in_mm
+    db = geometry.borehole.radius_in_mm
+    rg = geometry.extra.topgroove.radius_in_mm
+    dg = geometry.extra.topgroove.depth_in_mm
+    db <= dg && @warn "The depth of the borehole ($(db)mm) should be bigger than the depth of the topgroove ($(dg)mm)."
+    return π * ((rg + fccd)^2 - (rb + fccd)^2) * dg
 end
 
 function get_extra_volume(geometry::PropDict, ::Val{:bottom_cylinder}, fccd::AbstractFloat)
+    # Find a picture of the definition of bottom_cylinder here:
+    # https://github.com/legend-exp/legend-metadata/blob/archived/hardware/detectors/detector-metadata_6.pdf
     r = geometry.extra.bottom_cylinder.radius_in_mm - fccd
     h = geometry.extra.bottom_cylinder.height_in_mm - fccd
     t = geometry.extra.bottom_cylinder.transition_in_mm

--- a/src/legend_data.jl
+++ b/src/legend_data.jl
@@ -318,7 +318,7 @@ function channelinfo(data::LegendData, sel::AnyValiditySelection; system::Symbol
                 else 
                     fccds[first(keys(fccds))].value
                 end
-                active_volume::Unitful.Volume{<:Float64} = if haskey(diodmap, k) get_active_volume(diodmap[k], 0.0) else Float64(NaN) * u"cm^3" end
+                active_volume::Unitful.Volume{<:Float64} = if haskey(diodmap, k) get_active_volume(diodmap[k], fccd) else Float64(NaN) * u"cm^3" end
                 c = merge(c, (; cc4, cc4ch, daqcrate, daqcard, hvcard, hvch, enrichment, mass, total_volume, active_volume))
             end
             


### PR DESCRIPTION
Currently, the active volume calculation for detectors with cracks was not implemented.
I did the calculation and added the formulas for vertical and inclined cracks to the code.

The only thing missing is the handling of `fccd`, 
@fhagemann: could you add this?