### PR TITLE
Support dot-based getproperty in ljl_propfunc

### DIFF
--- a/src/ljl_expressions.jl
+++ b/src/ljl_expressions.jl
@@ -30,30 +30,33 @@ end
 export parse_ljlexpr
 
 
-const ljl_expr_allowed_heads = [:., :ref, :call, :macrocall, :||, :&&, :comparison, :if]
+const ljl_expr_allowed_heads = Symbol[:., :ref, :call, :macrocall, :||, :&&, :comparison, :if]
 
-const ljl_expr_allowed_funcs = Set([
+const ljl_expr_allowed_funcs = Set{Symbol}([
     :!,
     :(==), :<, :>, :>=, :<=, :!=,
-    :isapprox, :≈, :≈,
+    :isapprox, :≈,
     :in, :∈, :..,
-    :+, :-, :*, :/,
+    :+, :-, :*, :/, :div, :rem, :mod,
+    :|, :&, :xor,
     :^, :sqrt,
     :one, :zero, :identity,
     :abs, :abs2, :normalize, :norm,
     :exp, :exp2, :exp10, :log, :log2, :log10,
     :sin, :cos, :tan, :asin, :acos, :atan,
+    :min, :max,
     :isnan, :isinf, :isfinite,
     :all, :any, :broadcast,
-    :get, :getproperty,
-    :value, :uncertainty, :stdscore, :weightedmean,
-    :±, 
+    :sum, :prod, :minimum, :maximum, :mean,
+    :get, :getproperty, :getindex, :first, :last,
+    :haskey, :isempty, :length, :size,
     :(:), :Symbol, :String, :Int, :Float64, :Bool,
     :string, :parse,
+    :value, :uncertainty, :stdscore, :weightedmean, :±, 
     :DetectorId, :ChannelId
 ])
 
-const _ljlexpr_units = IdDict([
+const _ljlexpr_units = IdDict{Symbol,Expr}([
     :s => :(u"s"),
     :ms => :(u"ms"),
     :μs => :(u"μs"),

--- a/src/ljl_expressions.jl
+++ b/src/ljl_expressions.jl
@@ -30,7 +30,7 @@ end
 export parse_ljlexpr
 
 
-const ljl_expr_allowed_heads = [:., :ref, :call, :macrocall, :||, :&&, :comparison]
+const ljl_expr_allowed_heads = [:., :ref, :call, :macrocall, :||, :&&, :comparison, :if]
 
 const ljl_expr_allowed_funcs = Set([
     :!,
@@ -39,6 +39,7 @@ const ljl_expr_allowed_funcs = Set([
     :in, :∈, :..,
     :+, :-, :*, :/,
     :^, :sqrt,
+    :one, :zero, :identity,
     :abs, :abs2, :normalize, :norm,
     :exp, :exp2, :exp10, :log, :log2, :log10,
     :sin, :cos, :tan, :asin, :acos, :atan,

--- a/test/test_ljl_expressions.jl
+++ b/test/test_ljl_expressions.jl
@@ -36,10 +36,10 @@ include("testing_utils.jl")
     @test num_pf === ljl_propfunc(num_expr_string)
     @test @inferred(broadcast(num_pf, data)) == ref_numfunc.(data)
 
-    meas_expr_string = "(offs + slope * abs(E_trap) / 1000) - (5.2 ± 0.1)"
+    meas_expr_string = "(offs + (slope > 0.5 ? one(slope) : zero(slope)) * abs(E_trap) / 1000) - (5.2 ± 0.1)"
     meas_expr = parse_ljlexpr(meas_expr_string)
-    @test meas_expr == :((offs + (slope * abs(E_trap)) / 1000) - (5.2 ± 0.1))
-    ref_measfunc(x) = (x.offs + (x.slope * abs(x.E_trap)) / 1000) - Measurements.:(±)(5.2, 0.1)
+    @test meas_expr == :((offs + ((slope > 0.5 ? one(slope) : zero(slope)) * abs(E_trap)) / 1000) - (5.2 ± 0.1))
+    ref_measfunc(x) = (x.offs + ((x.slope > 0.5 ? one(x.slope) : zero(x.slope)) * abs(x.E_trap)) / 1000) - Measurements.:(±)(5.2, 0.1)
     meas_pf = ljl_propfunc(meas_expr)
     @test meas_pf isa PropertyFunctions.PropertyFunction
     @test meas_pf === ljl_propfunc(meas_expr_string)

--- a/test/test_ljl_expressions.jl
+++ b/test/test_ljl_expressions.jl
@@ -49,4 +49,7 @@ include("testing_utils.jl")
     multi_pf = ljl_propfunc(expr_map)
     @test multi_pf isa PropertyFunctions.PropertyFunction
     @test @inferred(broadcast(multi_pf, data)) == StructArray(e_cal = ref_numfunc.(data), e_flag = ref_boolfunc.(data))
+
+    @test @inferred(ljl_propfunc("a.+b")((a = [1,2,3], b = [5, 6, 7]))) == [6, 8, 10]
+    @test @inferred(ljl_propfunc("log.(a)")((a = [1,2,3],))) ≈ [0.0, 0.6931471805599453, 1.0986122886681098]
 end

--- a/test/test_ljl_expressions.jl
+++ b/test/test_ljl_expressions.jl
@@ -6,28 +6,31 @@ using Test
 using PropertyFunctions, StructArrays
 import Measurements
 
+using PropDicts: PropDict
+
 include("testing_utils.jl")
 
 @testset "legend_expressions" begin
     data = StructArray([
-        (E_trap = 21092, offs = 0.01, slope = 0.73, A = 328.2, force_accept = false),
-        (E_trap = 21092, offs = 0.01, slope = 0.73, A = NaN, force_accept = false),
-        (E_trap = 21092, offs = 0.01, slope = 0.73, A = NaN, force_accept = true),
+        (E_trap = 21092, offs = 0.01, slope = 0.73, A = 328.2, force_accept = false, a = (b = [1,41,3], c = 51.1)),
+        (E_trap = 21092, offs = 0.01, slope = 0.73, A = NaN, force_accept = false, a = (b = [1,42,3], c = 32.0)),
+        (E_trap = 21092, offs = 0.01, slope = 0.73, A = NaN, force_accept = true, a = (b = [1,41,3], c = 51.1)),
+        (E_trap = 21092, offs = 0.01, slope = 0.73, A = NaN, force_accept = true, a = (b = [1,42,3], c = 32.03)),
     ])
 
-    bool_expr_string = "E_trap > 0 && !isnan(A) && !isinf(E_trap) || force_accept"
+    bool_expr_string = "E_trap > 0 && !isnan(A) && !isinf(E_trap) || force_accept && a.b[2] > a.c"
     bool_expr = parse_ljlexpr(bool_expr_string)
-    @test bool_expr == :(E_trap > 0 && (!(isnan(A)) && !(isinf(E_trap))) || force_accept)
-    ref_boolfunc(x) = (x.E_trap > 0 && !(isnan(x.A)) && !(isinf(x.E_trap)) || x.force_accept)
+    @test bool_expr == :(E_trap > 0 && (!(isnan(A)) && !(isinf(E_trap))) || force_accept && a.b[2] > a.c)
+    ref_boolfunc(x) = (x.E_trap > 0 && !(isnan(x.A)) && !(isinf(x.E_trap)) || x.force_accept && x.a.b[2] > x.a.c)
     bool_pf = ljl_propfunc(bool_expr)
     @test bool_pf isa PropertyFunctions.PropertyFunction
     @test bool_pf === ljl_propfunc(bool_expr_string)
     @test @inferred(broadcast(bool_pf, data)) == ref_boolfunc.(data)
 
-    num_expr_string = "(offs + slope * abs(E_trap) / 1000) - 5.2"
+    num_expr_string = "(offs + slope * abs(E_trap) / 1000) - 5.2 + a.b[2]/100 * a.c/50"
     num_expr = parse_ljlexpr(num_expr_string)
-    @test num_expr == :((offs + (slope * abs(E_trap)) / 1000) - 5.2)
-    ref_numfunc(x) = (x.offs + (x.slope * abs(x.E_trap)) / 1000) - 5.2
+    @test num_expr == :((offs + (slope * abs(E_trap)) / 1000) - 5.2 + a.b[2]/100 * a.c/50)
+    ref_numfunc(x) = (x.offs + (x.slope * abs(x.E_trap)) / 1000) - 5.2 + x.a.b[2]/100 * x.a.c/50
     num_pf = ljl_propfunc(num_expr)
     @test num_pf isa PropertyFunctions.PropertyFunction
     @test num_pf === ljl_propfunc(num_expr_string)


### PR DESCRIPTION
Also add support for square-brackets index access, the conditional ternary operator and functions `one`, `zero` and `identity`.