### PR TITLE
Bug fix `lprops`

### DIFF
--- a/Project.toml
+++ b/Project.toml
@@ -29,6 +29,7 @@ Tables = "bd369af6-aec1-5ad0-b16a-f7cc5008161c"
 TypedTables = "9d95f2ec-7b3d-5a63-8d20-e2491e220bb9"
 UUIDs = "cf7118a7-6976-5b1a-9a39-7adc72f591a4"
 Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
+UnitfulAtomic = "a7773ee8-282e-5fa2-be4e-bd808c38a91a"
 
 [weakdeps]
 LegendDataTypes = "99e09c13-5545-5ee2-bfa2-77f358fb75d8"
@@ -73,4 +74,5 @@ Tables = "1.1"
 TypedTables = "1.4"
 UUIDs = "<0.0.1, 1"
 Unitful = "1.11"
+UnitfulAtomic = "1"
 julia = "1.10"

--- a/src/LegendDataManagement.jl
+++ b/src/LegendDataManagement.jl
@@ -17,6 +17,7 @@ using PropDicts
 using PropertyDicts
 using StructArrays
 using Unitful
+using UnitfulAtomic
 using Measurements
 using Measurements: ±, value, uncertainty
 


### PR DESCRIPTION
To properly parse units with e.g. special units from `UnitfulAtomic`, the function `unit_from_string` from `LegendDataTypes` is now used to avoid that.