### PR TITLE
Add uncertainties for active volume calculation

### DIFF
--- a/test/Project.toml
+++ b/test/Project.toml
@@ -17,4 +17,4 @@ Unitful = "1986cc42-f94f-5a68-af5c-568840ba703d"
 
 [compat]
 Documenter = "1"
-LegendTestData = "0.2.9"
+LegendTestData = "0.2.10"

--- a/test/test_legend_data.jl
+++ b/test/test_legend_data.jl
@@ -4,6 +4,7 @@ using LegendDataManagement
 using Test
 
 using StructArrays, PropertyFunctions, TypedTables
+using Measurements: uncertainty
 
 include("testing_utils.jl")
 
@@ -38,6 +39,8 @@ include("testing_utils.jl")
         extended_keywords = (:cc4, :cc4ch, :daqcrate, :daqcard, :hvcard, :hvch, :enrichment, :mass, :total_volume, :active_volume)
         @test !any(in(columnnames(chinfo)),   extended_keywords)
         @test  all(in(columnnames(extended)), extended_keywords)
+        @test !any(iszero.(uncertainty.(extended.fccd)))
+        @test !any(iszero.(uncertainty.(extended.active_volume)))
 
         # ToDo: Make type-stable:
         # @test #=@inferred=#(channel_info(l200, filekey)) isa StructArray


### PR DESCRIPTION
Alternative to #80 (which can be used once https://github.com/legend-exp/legend-detectors/pull/48 is merged and according dummy values are added to legend-testdata).

I am not sure if `Measurements` can deal with asymmetric errors, so right now I'm estimating the uncertainty as the maximum number quoted as `uncertainty` in the metadata (`pos` and `neg`).
