### PR TITLE
Patch `channelinfo`

### DIFF
--- a/src/exposure.jl
+++ b/src/exposure.jl
@@ -87,14 +87,7 @@ function _get_exposure(data::LegendData, det::DetectorIdLike, rinfo::Table, is_a
     mass = if !iszero(livetime) && !isempty(filekeys)
         # read in the channelinfo
         filekey = first(filekeys)
-        _chinfo = channelinfo(data, filekey, det, extended = true, verbose = false)
-        chinfo = if !all(x -> hasproperty(_chinfo, x), (:enrichment, :mass, :active_volume, :total_volume))
-            empty!(_cached_channelinfo)
-            channelinfo(data, filekey, det, extended = true, verbose = false)
-        else
-            _chinfo
-        end
-        # chinfo.active_volume == chinfo.total_volume && @warn "No FCCD value given for detector $(det)"
+        chinfo = channelinfo(data, filekey, det, extended = true, verbose = false)
         chinfo.mass * chinfo.enrichment * chinfo.active_volume / chinfo.total_volume
     else
         0.0u"kg"

--- a/test/test_legend_data.jl
+++ b/test/test_legend_data.jl
@@ -30,9 +30,6 @@ include("testing_utils.jl")
         @test all(filterby(@pf $processable && $usability == :on)(chinfo).processable)
         @test all(filterby(@pf $processable && $usability == :on)(chinfo).usability .== :on)
 
-        # Delete the channelinfo cache
-        empty!(LegendDataManagement._cached_channelinfo)
-
         # Test the extended channel info with active volume calculation
         extended = channelinfo(l200, filekey, only_usability = :on, extended = true)
         @test extended isa TypedTables.Table


### PR DESCRIPTION
`extended` kwarg is used for cashing of `channelinfo` to prevent long loading times. This was a bug since before the user hat to manually reset the cache by creating a new `LegendData` object if the `extended` kwarg was used after the function was called witout before.

Minor bug fixes in column layout 