### PR TITLE
Bug Fix `read_ldata`

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -94,6 +94,7 @@ For simplicity, the ch can also be given as a `DetectorID` which will be convert
 det = chinfo[1].detector
 dsp = read_ldata(l200, :jldsp, :cal, :p03, :r000, det)
 ```
+In case, a `ChannelId` is missing in a file, the function will throw an `ArgumentError`. To avoid this and return `nothing` instead, you can use the `ignore_missing` keyword argument.
 ## `SolidStateDetectors` extension
 
 LegendDataManagment provides an extension for [SolidStateDetectors](https://github.com/JuliaPhysics/SolidStateDetectors.jl). This makes it possible to create `SolidStateDetector` and `Simulation` instances from LEGEND metadata.


### PR DESCRIPTION
Included `ignore_missing` kwarg in `read_ldata` to be able to ignore missing channels. In particular useful for Water Cherenkov PMT analysis.
``` julia
raw = read_ldata(l200, DataTier(:raw), :phy, :p03, :r000, ch; ignore_missing=true)
```

