### PR TITLE
Updated `calibration_functions` and `evt_functions`

### DIFF
--- a/src/calibration_functions.jl
+++ b/src/calibration_functions.jl
@@ -251,7 +251,7 @@ const _cached_dataprod_spms_cal = LRU{Tuple{UInt, AnyValiditySelection}, Union{P
 
 function _dataprod_spms_cal(data::LegendData, sel::AnyValiditySelection)
     key = (objectid(data), sel)
-    get!(_cached_dataprod_ged_cal, key) do
+    get!(_cached_dataprod_spms_cal, key) do
         dataprod_config(data).sipm(sel)
     end
 end

--- a/src/evt_functions.jl
+++ b/src/evt_functions.jl
@@ -135,3 +135,15 @@ function get_spms_evt_chsel_propfunc(data::LegendData, sel::AnyValiditySelection
 end
 export get_spms_evt_chsel_propfunc
 
+
+"""
+    get_spms_evt_lar_cut_props(data::LegendData, sel::AnyValiditySelection)
+
+Get the SiPM LAr cut properties.
+"""
+function get_spms_evt_lar_cut_props(data::LegendData, sel::AnyValiditySelection)
+    _dataprod_evt(data, sel, :spms).lar_cut
+end
+export get_spms_evt_lar_cut_props
+
+

--- a/src/ljl_expressions.jl
+++ b/src/ljl_expressions.jl
@@ -65,7 +65,7 @@ const _ljlexpr_units = IdDict{Symbol,Expr}([
     :MeV => :(u"MeV"),
     :keV => :(u"keV"),
     :eV => :(u"eV"),
-    :e => :(u"e"),
+    :e => :(u"e_au"),
 ])
 _ljl_expr_unitmap(sym::Symbol) = get(_ljlexpr_units, sym, sym)
 

--- a/src/ljl_expressions.jl
+++ b/src/ljl_expressions.jl
@@ -65,6 +65,7 @@ const _ljlexpr_units = IdDict{Symbol,Expr}([
     :MeV => :(u"MeV"),
     :keV => :(u"keV"),
     :eV => :(u"eV"),
+    :e => :(u"e"),
 ])
 _ljl_expr_unitmap(sym::Symbol) = get(_ljlexpr_units, sym, sym)
 


### PR DESCRIPTION
Updated calibration and evt functions to work properly with latest `metadata`, `pars` and `jlevt` level updates.

See [PR#13](https://github.com/legend-exp/LegendEventAnalysis.jl/pull/13) of `LegendEventAnalysis`