### PR TITLE
`LQ` calibration functions and `PSD` propfuncs

### DIFF
--- a/src/calibration_functions.jl
+++ b/src/calibration_functions.jl
@@ -19,7 +19,7 @@ function _get_ecal_props(data::LegendData, sel::AnyValiditySelection, detector::
 end
 
 function _get_e_cal_propsfunc_str(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, e_filter::Symbol; kwargs...)
-    ecal_props::String = get(get(get(_get_ecal_props(data, sel, detector; kwargs...), e_filter, PropDict()), :cal, PropDict()), :func, "e_max * NaN*keV")
+    ecal_props::String = get(get(get(_get_ecal_props(data, sel, detector; kwargs...), e_filter, PropDict()), :cal, PropDict()), :func, "$(e_filter) * NaN*keV")
     return ecal_props
 end
 
@@ -75,7 +75,7 @@ function _get_aoecal_props(data::LegendData, sel::AnyValiditySelection, detector
 end
 
 function _get_aoe_cal_propfunc_str(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, aoe_type::Symbol; pars_type::Symbol=:ppars, pars_cat::Symbol=:aoe)
-    aoecal_props::String = get(_get_aoecal_props(data, sel, detector; pars_type=pars_type, pars_cat=pars_cat)[aoe_type], :func, "a_raw * NaN")
+    aoecal_props::String = get(_get_aoecal_props(data, sel, detector; pars_type=pars_type, pars_cat=pars_cat)[aoe_type], :func, "$(aoe_type) * NaN")
     return aoecal_props
 end
 
@@ -94,7 +94,7 @@ function _get_lqcal_props(data::LegendData, sel::AnyValiditySelection, detector:
 end
 
 function _get_lq_cal_propfunc_str(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, lq_type::Symbol; pars_type::Symbol=:ppars, pars_cat::Symbol=:lq)
-    lqcal_props::String = get(_get_lqcal_props(data, sel, detector; pars_type=pars_type, pars_cat=pars_cat)[lq_type], :func, "lq * NaN")
+    lqcal_props::String = get(_get_lqcal_props(data, sel, detector; pars_type=pars_type, pars_cat=pars_cat)[lq_type], :func, "$(lq_type) * NaN")
     return lqcal_props
 end
 
@@ -364,7 +364,7 @@ function _get_larcal_props(data::LegendData, sel::AnyValiditySelection, detector
 end
 
 function _get_larcal_propfunc_str(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, e_filter::Symbol; kwargs...)
-    ecal_props::String = get(get(get(_get_larcal_props(data, sel, detector; kwargs...), e_filter, PropDict()), :cal, PropDict()), :func, "trig_max .* (NaN*e)")
+    ecal_props::String = get(get(get(_get_larcal_props(data, sel, detector; kwargs...), e_filter, PropDict()), :cal, PropDict()), :func, "$(e_filter) .* (NaN*e)")
     return ecal_props
 end
 

--- a/src/calibration_functions.jl
+++ b/src/calibration_functions.jl
@@ -246,11 +246,11 @@ export dataprod_pars_aoe_window
 
 
 function _get_ged_aoe_lowcut_propfunc_str(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, aoe_classifier::Symbol; pars_type::Symbol=:ppars, pars_cat::Symbol=:aoe)
-    "$(aoe_classifier) > $(leftendpoint(dataprod_pars_aoe_window(data, sel, detector, aoe_classifier; pars_type=pars_type, pars_cat=pars_cat)))"
+    "$(aoe_classifier) < $(leftendpoint(dataprod_pars_aoe_window(data, sel, detector, aoe_classifier; pars_type=pars_type, pars_cat=pars_cat)))"
 end
 
 function _get_ged_aoe_dscut_propfunc_str(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, aoe_classifier::Symbol; pars_type::Symbol=:ppars, pars_cat::Symbol=:aoe)
-    "$(aoe_classifier) > $(leftendpoint(dataprod_pars_aoe_window(data, sel, detector, aoe_classifier; pars_type=pars_type, pars_cat=pars_cat))) && $(aoe_classifier) < $(rightendpoint(dataprod_pars_aoe_window(data, sel, detector, aoe_classifier; pars_type=pars_type, pars_cat=pars_cat)))"
+    "$(aoe_classifier) < $(leftendpoint(dataprod_pars_aoe_window(data, sel, detector, aoe_classifier; pars_type=pars_type, pars_cat=pars_cat))) && $(aoe_classifier) > $(rightendpoint(dataprod_pars_aoe_window(data, sel, detector, aoe_classifier; pars_type=pars_type, pars_cat=pars_cat)))"
 end
 
 """


### PR DESCRIPTION
This PR includes the `LQ` calibration functions and `PSD` classifier defintions:
- `LQ` calibration and cut definition
- `psd_classifier` propfunc

**Attention**: This PR inverts the `A/E` and `LQ` cut logic: Any `classifier_cut` parameter is now `true` if the event should be cut. This makes the `PSD` part consisten with the rest of the `jlevt` level.

**Note**: This PR only works in combination with [PR#14](https://github.com/legend-exp/LegendEventAnalysis.jl/pull/14) in `LegendEventAnalysis`