### PR TITLE
Bug fix `calibration_functions` default case + Update `evt_functions`

### DIFF
--- a/src/calibration_functions.jl
+++ b/src/calibration_functions.jl
@@ -19,7 +19,7 @@ function _get_ecal_props(data::LegendData, sel::AnyValiditySelection, detector::
 end
 
 function _get_e_cal_propsfunc_str(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, e_filter::Symbol; kwargs...)
-    ecal_props::String = get(get(get(_get_ecal_props(data, sel, detector; kwargs...), e_filter, PropDict()), :cal, PropDict()), :func, "$(e_filter) * NaN*keV")
+    ecal_props::String = get(get(get(_get_ecal_props(data, sel, detector; kwargs...), e_filter, PropDict()), :cal, PropDict()), :func, "blmean * NaN*keV")
     return ecal_props
 end
 
@@ -75,7 +75,7 @@ function _get_aoecal_props(data::LegendData, sel::AnyValiditySelection, detector
 end
 
 function _get_aoe_cal_propfunc_str(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, aoe_type::Symbol; pars_type::Symbol=:ppars, pars_cat::Symbol=:aoe)
-    aoecal_props::String = get(_get_aoecal_props(data, sel, detector; pars_type=pars_type, pars_cat=pars_cat)[aoe_type], :func, "$(aoe_type) * NaN")
+    aoecal_props::String = get(_get_aoecal_props(data, sel, detector; pars_type=pars_type, pars_cat=pars_cat)[aoe_type], :func, "blmean * NaN")
     return aoecal_props
 end
 
@@ -94,7 +94,7 @@ function _get_lqcal_props(data::LegendData, sel::AnyValiditySelection, detector:
 end
 
 function _get_lq_cal_propfunc_str(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, lq_type::Symbol; pars_type::Symbol=:ppars, pars_cat::Symbol=:lq)
-    lqcal_props::String = get(_get_lqcal_props(data, sel, detector; pars_type=pars_type, pars_cat=pars_cat)[lq_type], :func, "$(lq_type) * NaN")
+    lqcal_props::String = get(_get_lqcal_props(data, sel, detector; pars_type=pars_type, pars_cat=pars_cat)[lq_type], :func, "blmean * NaN")
     return lqcal_props
 end
 

--- a/src/evt_functions.jl
+++ b/src/evt_functions.jl
@@ -46,6 +46,16 @@ function get_ged_evt_hitchsel_propfunc(data::LegendData, sel::AnyValiditySelecti
 end
 export get_ged_evt_hitchsel_propfunc
 
+"""
+    get_ged_evt_is_valid_hit_properties(data::LegendData, sel::AnyValiditySelection)
+
+Get the hit Ge-detector `is_valid_hit` selection properties.
+"""
+function get_ged_evt_is_valid_hit_properties(data::LegendData, sel::AnyValiditySelection)
+    Symbol.(_dataprod_evt(data, sel, :geds).is_valid_hit_properties)
+end
+export get_ged_evt_is_valid_hit_properties
+
 
 """
     get_ged_evt_kwargs(data::LegendData, sel::AnyValiditySelection)


### PR DESCRIPTION
This PR updates the `calibration_functions` to use `blmean` as default column in the DSP output which always exists. Furthermore, it updates the `evt_functions` with `get_ged_evt_is_valid_hit_properties` to allow selectable `is_valid_hit` properties.

**Note**: Part of this PR work only in combination with [PR#15](https://github.com/legend-exp/LegendEventAnalysis.jl/pull/15) in `LegendEventAnalysis`