### PR TITLE
`PMT` calibration + event level functions 

### DIFF
--- a/src/calibration_functions.jl
+++ b/src/calibration_functions.jl
@@ -333,7 +333,7 @@ end
 export get_ged_psd_classifier_propfunc
 
 
-### SiPM LAr cut functions
+### SiPM LAr cal functions
 
 const _cached_dataprod_spms_cal = LRU{Tuple{UInt, AnyValiditySelection}, Union{PropDict,PropDicts.MissingProperty}}(maxsize = 10^3)
 
@@ -388,11 +388,11 @@ end
 Get the LAr/SPMS calibration function for the given data, validity selection
 and detector.
 """
-function get_spm_cal_propfunc(data::LegendData, sel::AnyValiditySelection, detector::DetectorId; pars_type::Symbol=:ppars)
+function get_spm_cal_propfunc(data::LegendData, sel::AnyValiditySelection, detector::DetectorId; pars_type::Symbol=:ppars, pars_cat::Symbol=:sipmcal)
     let energies = keys(_dataprod_lar_cal(data, sel, detector; pars_type=pars_type).energy_types), energies_cal = Symbol.(string.(keys(_dataprod_lar_cal(data, sel, detector; pars_type=pars_type).energy_types)) .* "_cal")
         ljl_propfunc(
             Dict{Symbol, String}(
-                energies_cal .=> _get_larcal_propfunc_str.(Ref(data), Ref(sel), Ref(detector), energies; pars_type=pars_type)
+                energies_cal .=> _get_larcal_propfunc_str.(Ref(data), Ref(sel), Ref(detector), energies; pars_type=pars_type, pars_cat=pars_cat)
             )
         )
     end
@@ -425,3 +425,6 @@ function get_spm_dc_cal_propfunc(data::LegendData, sel::AnyValiditySelection, de
     end
 end
 export get_spm_dc_cal_propfunc
+
+
+

--- a/src/evt_functions.jl
+++ b/src/evt_functions.jl
@@ -128,7 +128,7 @@ export get_aux_evt_chsel_propfunc
 """
     get_spms_evt_chdata_propfunc(data::LegendData, sel::AnyValiditySelection)
 
-Get the Ge-detector channel data output PropertyFunction.
+Get the SiPM-detector channel data output PropertyFunction.
 """
 function get_spms_evt_chdata_propfunc(data::LegendData, sel::AnyValiditySelection)
     ljl_propfunc(_dataprod_evt(data, sel, :spms).chdata_output)
@@ -168,3 +168,57 @@ end
 export get_spms_evt_lar_cut_props
 
 
+### PMTS
+
+"""
+    get_pmts_evt_chdata_propfunc(data::LegendData, sel::AnyValiditySelection)
+
+Get the PMT-detector channel data output PropertyFunction.
+"""
+function get_pmts_evt_chdata_propfunc(data::LegendData, sel::AnyValiditySelection)
+    ljl_propfunc(_dataprod_evt(data, sel, :pmts).chdata_output)
+end
+export get_pmts_evt_chdata_propfunc
+
+"""
+    get_pmts_evt_chsel_propfunc(data::LegendData, sel::AnyValiditySelection)
+
+Get the PMT channel selection PropertyFunction.
+"""
+function get_pmts_evt_chsel_propfunc(data::LegendData, sel::AnyValiditySelection)
+    ljl_propfunc(_dataprod_evt(data, sel, :pmts).channels)
+end
+export get_pmts_evt_chsel_propfunc
+
+
+"""
+    get_pmts_evt_kwargs(data::LegendData, sel::AnyValiditySelection)
+
+Get the PMT evt kwargs.
+"""
+function get_pmts_evt_kwargs(data::LegendData, sel::AnyValiditySelection)
+    kwargs = _dataprod_evt(data, sel, :pmts).kwargs
+    NamedTuple([(k, if v isa String Symbol(v) else v end) for (k, v) in pairs(kwargs)])
+end
+export get_pmts_evt_kwargs
+
+"""
+    get_pmts_evt_muon_cut_props(data::LegendData, sel::AnyValiditySelection)
+
+Get the PMT muon cut properties.
+"""
+function get_pmts_evt_muon_cut_props(data::LegendData, sel::AnyValiditySelection)
+    _dataprod_evt(data, sel, :pmts).muon_cut
+end
+export get_pmts_evt_muon_cut_props
+
+
+"""
+    get_pmts_evt_evtdata_propfunc(data::LegendData, sel::AnyValiditySelection)
+
+Get the PMT-detector channel data output PropertyFunction.
+"""
+function get_pmts_evt_evtdata_propfunc(data::LegendData, sel::AnyValiditySelection)
+    ljl_propfunc(get_pmts_evt_muon_cut_props(data, sel).evtdata_output)
+end
+export get_pmts_evt_evtdata_propfunc

--- a/src/evt_functions.jl
+++ b/src/evt_functions.jl
@@ -136,6 +136,17 @@ end
 export get_spms_evt_chdata_propfunc
 
 """
+    get_spms_evt_kwargs(data::LegendData, sel::AnyValiditySelection)
+
+Get the SiPM-detector evt kwargs.
+"""
+function get_spms_evt_kwargs(data::LegendData, sel::AnyValiditySelection)
+    kwargs = _dataprod_evt(data, sel, :spms).kwargs
+    NamedTuple([(k, if v isa String Symbol(v) else v end) for (k, v) in pairs(kwargs)])
+end
+export get_spms_evt_kwargs
+
+"""
     get_spms_evt_chsel_propfunc(data::LegendData, sel::AnyValiditySelection)
 
 Get the SiPM channel selection PropertyFunction.


### PR DESCRIPTION
This PR includes `jlevt` and calibration functions for the `PMT` veto system. In addition, the `is_physical_trig` propfunc is generated.

**Note**: This PR only works in combination with [PR#16](https://github.com/legend-exp/LegendEventAnalysis.jl/pull/16) in `LegendEventAnalysis`