### PR TITLE
Avoid using deprecated method for `getproperties`

### DIFF
--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -134,9 +134,9 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
             end
         elseif f isa PropSelFunction
             if !isempty(string((ch)))
-                _load_all_keys(getproperties(_propfunc_columnnames(f)...)(h[ch, tier]), n_evts)
+                _load_all_keys(getproperties(_propfunc_columnnames(f))(h[ch, tier]), n_evts)
             else
-                _load_all_keys(getproperties(_propfunc_columnnames(f)...)(h[tier]), n_evts)
+                _load_all_keys(getproperties(_propfunc_columnnames(f))(h[tier]), n_evts)
             end
         else
             result = if !isempty(string((ch)))


### PR DESCRIPTION
Looks like we are using a deprecated method for `TypesTable.getproperties` in our package:
https://github.com/JuliaData/TypedTables.jl/blob/702cf7fdde8d6ac9822c8f43d695b50f6b183508/src/properties.jl#L87

I did not test whether this still works, but it's throwing deprecation warnings in tests.