### PR TITLE
Add more methods to create SSD objects from metadata

### DIFF
--- a/ext/LegendDataManagementSolidStateDetectorsExt.jl
+++ b/ext/LegendDataManagementSolidStateDetectorsExt.jl
@@ -19,8 +19,12 @@ LegendDataManagement provides an extension for SolidStateDetectors, a
 `SolidStateDetector` can be constructed from LEGEND metadata using the
 methods above.
 """
-function SolidStateDetectors.SolidStateDetector(data::LegendData, meta::Union{<:String, <:AbstractDict, <:DetectorIdLike}, env::HPGeEnvironment = HPGeEnvironment())
-    SolidStateDetector{_SSDDefaultNumtype}(data, meta, env)
+function SolidStateDetectors.SolidStateDetector(data::LegendData, detector::DetectorIdLike, env::HPGeEnvironment = HPGeEnvironment())
+    SolidStateDetector{_SSDDefaultNumtype}(data, detector, env)
+end
+
+function SolidStateDetectors.SolidStateDetector(::LegendData, meta::Union{<:String, <:AbstractDict}, env::HPGeEnvironment = HPGeEnvironment())
+    SolidStateDetector{_SSDDefaultNumtype}(LegendData, meta, env)
 end
 
 function SolidStateDetectors.SolidStateDetector{T}(data::LegendData, detector::DetectorIdLike, env::HPGeEnvironment = HPGeEnvironment()) where {T<:AbstractFloat}
@@ -51,7 +55,11 @@ LegendDataManagement provides an extension for SolidStateDetectors, a
 `Simulation` can be constructed from LEGEND metadata using the
 methods above.
 """
-function SolidStateDetectors.Simulation(::Type{LegendData}, meta::Union{<:String, <:AbstractDict, <:DetectorIdLike}, env::HPGeEnvironment = HPGeEnvironment())
+function SolidStateDetectors.Simulation(data::LegendData, detector::DetectorIdLike, env::HPGeEnvironment = HPGeEnvironment())
+    Simulation{_SSDDefaultNumtype}(data, detector, env)
+end
+
+function SolidStateDetectors.Simulation(::Type{LegendData}, meta::Union{<:String, <:AbstractDict}, env::HPGeEnvironment = HPGeEnvironment())
     Simulation{_SSDDefaultNumtype}(LegendData, meta, env)
 end
 

--- a/test/test_ext_ssd.jl
+++ b/test/test_ext_ssd.jl
@@ -14,6 +14,8 @@ include("testing_utils.jl")
     l200 = LegendData(:l200)
     for detname in (:V99000A, :B99000A, :C99000A, :P99000A)
         @testset "$(detname)" begin
+            det = SolidStateDetector(l200, detname)
+            @test det isa SolidStateDetector
             det = SolidStateDetector{Float64}(l200, detname) 
             @test det isa SolidStateDetector
             sim = Simulation{Float64}(l200, detname)
@@ -39,6 +41,8 @@ include("testing_utils.jl")
     @testset "Test HPGeEnvironment" begin
         detname = :V99000A
         env = LegendDataManagement.HPGeEnvironment("LAr", 87u"K")
+        sim = Simulation(l200, detname, env)
+        @test sim isa Simulation
         sim = Simulation{Float64}(l200, detname, env)
         @test sim isa Simulation
         @test sim.medium == SolidStateDetectors.material_properties[:LAr]


### PR DESCRIPTION
Some things got a bit mixed up in #91.
For example
```julia
l200 = LegendData(:l200)
sim = Simulation(l200, :V00050A)
```
seemed to work in the past but doesn't now. It explicitly requires a precision type in curly brackets:
```julia
sim = Simulation{T}(l200, :V00050A)
```

This should be fixed with this PR.