### PR TITLE
Parallel `read_ldata`

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -95,6 +95,20 @@ det = chinfo[1].detector
 dsp = read_ldata(l200, :jldsp, :cal, :p03, :r000, det)
 ```
 In case, a `ChannelId` is missing in a file, the function will throw an `ArgumentError`. To avoid this and return `nothing` instead, you can use the `ignore_missing` keyword argument.
+
+It is possible to read in multiple files in parallel using the `Distributed` functionalities from within a session. You can activate parallel read with the `parallel` kwarg.
+``` julia
+dsp = read_ldata(l200, :jldsp, :cal, DataPeriod(3), ch)
+dsp = read_ldata(l200, :jldsp, :cal, DataPeriod(3), ch; parallel=true)
+```
+However, it is necessary that a worker allocation was already performed and the `LegendDataManagement` as well as `LegendHDF5IO` package is loaded on all workers, e.g. with
+``` julia
+using Distributed
+addprocs(4)
+@everywhere using LegendDataManagement, LegendHDF5IO
+```
+In addition, the `wpool`kwarg allows to parse a custome `WorkerPool` for more sophisticated load patterns.
+
 ## `SolidStateDetectors` extension
 
 LegendDataManagment provides an extension for [SolidStateDetectors](https://github.com/JuliaPhysics/SolidStateDetectors.jl). This makes it possible to create `SolidStateDetector` and `Simulation` instances from LEGEND metadata.

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -179,8 +179,7 @@ end
 
 function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, AbstractVector{FileKey}, ChannelOrDetectorIdLike}; parallel::Bool=false, wpool::WorkerPool=default_worker_pool(), kwargs...)    
     @everywhere begin
-        @assert isdefined(Main, :LegendDataManagement) "Parallel read requires LegendDataManagement.jl and LegendHDF5IO.jl to be loaded on each worker.g. via `@everywhere using LegendDataManagement LegendHDF5IO`"
-        @assert isdefined(Main, :LegendHDF5IO) "Parallel read requires LegendDataManagement.jl and LegendHDF5IO.jl to be loaded on each worker.g. via `@everywhere using LegendDataManagement LegendHDF5IO`"
+        @assert isdefined(Main, :LegendDataManagement) && isdefined(Main, :LegendHDF5IO) "Parallel read requires LegendDataManagement.jl and LegendHDF5IO.jl to be loaded on each worker, e.g. via `@everywhere using LegendDataManagement LegendHDF5IO`"
     end
     lflatten(if parallel
                 @debug "Parallel read with $(length(workers())) workers from $(length(rsel[2])) filekeys"
@@ -266,7 +265,7 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
                 end
             else
                 @debug "Sequential read from $(length(rsel[3])) runs"
-                map(rsel[r]) do r
+                map(rsel[3]) do r
                     LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], r.period, r.run, rsel[4]); parallel=false, kwargs...)
                 end
             end)

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -261,7 +261,7 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
     lflatten(if parallel
                 @debug "Parallel read with $(length(workers())) workers from $(length(rsel[3])) runs"
                 pmap(wpool, rsel[3]) do r
-                    LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], r.period, r.run, rsel[4]); parallel=true, wpool=wpool, kwargs...)
+                    LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], r.period, r.run, rsel[4]); parallel, wpool, kwargs...)
                 end
             else
                 @debug "Sequential read from $(length(rsel[3])) runs"

--- a/test/test_legend_data.jl
+++ b/test/test_legend_data.jl
@@ -2,6 +2,7 @@
 
 using LegendDataManagement
 using Test
+using LegendHDF5IO
 
 using StructArrays, PropertyFunctions, TypedTables
 using Measurements: uncertainty
@@ -49,9 +50,61 @@ include("testing_utils.jl")
         # @test all(filterby(@pf $processable && $usability == :on)(chinfo).usability .== :on)
     end
 
+    # different config to check lh5 files
+    lh5testdata_dir = joinpath(legend_test_data_path(), "data", "lh5", "prod-ref-l200")
+    ENV["LEGEND_DATA_CONFIG"] = joinpath(lh5testdata_dir, "config.json")
+
+    l200_lh5 = LegendData(:l200)
+
     @testset "search_disk" begin
         datasets = search_disk(DataSet, l200)
         # LegendTestData is probably not in the correct formats
         @test_broken !(isempty(datasets))
+        # check search_disk
+        @test search_disk(DataTier, l200_lh5.tier[]) isa Vector{DataTier}
+        @test search_disk(DataCategory, l200_lh5.tier[:dsp]) isa Vector{DataCategory}
+        @test search_disk(DataPeriod, l200_lh5.tier[:dsp, :cal]) isa Vector{DataPeriod}
+        @test search_disk(DataRun, l200_lh5.tier[:dsp, :cal, :p03]) isa Vector{DataRun}
+        @test search_disk(FileKey, l200_lh5.tier[:dsp, :cal, :p03, :r000]) isa Vector{FileKey}
+    end
+
+    @testset "read_ldata" begin
+        # Test the read_ldata function
+        period = DataPeriod(3)
+        run = DataRun(0)
+        cat = DataCategory(:cal)
+        tier = DataTier(:dsp)
+        fk = search_disk(FileKey, l200_lh5.tier[tier, cat, period, run])[1]
+
+        ch_str, data_fk = lh5open(l200_lh5.tier[tier, fk]) do f
+            first(keys(f)), f[Symbol(first(keys(f))), Symbol(tier)][:]
+        end
+        @test ChannelId(ch_str) isa ChannelId
+        @test data_fk isa TypedTables.Table
+        ch = ChannelId(ch_str)
+
+        # test read_ldata
+        @test read_ldata(l200_lh5, tier, cat, period, run, ch) isa TypedTables.Table
+        @test read_ldata(l200_lh5, tier, cat, period, run, ch).timestamp == data_fk.timestamp
+        @test read_ldata(:timestamp, l200_lh5, tier, cat, period, run, ch).timestamp == data_fk.timestamp
+        @test read_ldata((:timestamp, :baseline), l200_lh5, tier, cat, period, run, ch).timestamp == data_fk.timestamp
+        @test read_ldata(@pf($timestamp * $baseline), l200_lh5, tier, cat, period, run, ch) == data_fk.timestamp .* data_fk.baseline
+        @test read_ldata(l200_lh5, tier, fk, ch).timestamp == data_fk.timestamp
+        @test read_ldata(l200_lh5, tier, cat, period, run) isa TypedTables.Table
+
+        # test parallel read
+        @test read_ldata(l200_lh5, tier, cat, period, run, ch; parallel=true) isa TypedTables.Table
+        @test read_ldata(l200_lh5, tier, cat, period, run, ch; parallel=true).timestamp == data_fk.timestamp
+        @test read_ldata(:timestamp, l200_lh5, tier, cat, period, run, ch; parallel=true).timestamp == data_fk.timestamp
+        @test read_ldata((:timestamp, :baseline), l200_lh5, tier, cat, period, run, ch; parallel=true).timestamp == data_fk.timestamp
+        @test read_ldata(@pf($timestamp * $baseline), l200_lh5, tier, cat, period, run, ch; parallel=true) == data_fk.timestamp .* data_fk.baseline
+        @test read_ldata(l200_lh5, tier, fk, ch; parallel=true).timestamp == data_fk.timestamp
+        @test read_ldata(l200_lh5, tier, cat, period, run; parallel=true) isa TypedTables.Table
+        
+        # test multi run read
+        #ToDo: update legend-testdata to make possible
+        # rinfo = Table([(period = DataPeriod(3), run = DataRun(0)), (period = DataPeriod(3), run = DataRun(1))])
+
+        
     end
 end


### PR DESCRIPTION
This PR allows the use of `read_ldata` to read multiple files in parallel. The function `read_ldata` is extended by two additional `kwargs`:
- `parallel`: read files in parallel, default `false`
- `wpool`: worker pool to use for parallel read, only applies if `parallel = true`, default `default_worker_pool()` containing all workers 
The function automatically parallels all runs, periods and files for maximum speed. 