### PR TITLE
Rename LQ `highcut`

### DIFF
--- a/src/calibration_functions.jl
+++ b/src/calibration_functions.jl
@@ -284,7 +284,7 @@ Get the LQ cut window for the given data, validity selection and detector.
 """
 function dataprod_pars_lq_window(data::LegendData, sel::AnyValiditySelection, detector::DetectorId, lq_classifier::Symbol; pars_type::Symbol=:ppars, pars_cat::Symbol=:lq)
     lqcut_lo::Float64 = get(_get_lqcal_props(data, sel, detector; pars_type=pars_type, pars_cat=pars_cat)[lq_classifier], :lowcut, -Inf)
-    lqcut_hi::Float64 = get(_get_lqcal_props(data, sel, detector; pars_type=pars_type, pars_cat=pars_cat)[lq_classifier], :cut, Inf)
+    lqcut_hi::Float64 = get(_get_lqcal_props(data, sel, detector; pars_type=pars_type, pars_cat=pars_cat)[lq_classifier], :highcut, Inf)
     ClosedInterval(lqcut_lo, lqcut_hi)
 end
 


### PR DESCRIPTION
Renamed LQ `cut` --> `highcut` to deal with new dataflow update. 
This PR belongs to [PR#92](https://github.com/legend-exp/legend-julia-dataflow/pull/92) in `legend-julia-dataflow` to streamline the `LQ` naming convention with the other PSD parameters