### PR TITLE
Patch `PropsDB` overrides

### DIFF
--- a/src/props_db.jl
+++ b/src/props_db.jl
@@ -398,9 +398,10 @@ function _get_md_property(@nospecialize(pd::PropsDB), s::Symbol)
     new_relpath = push!(copy(_rel_path(pd)), string(s))
 
     json_primary_filename, json_override_filename = _propsdb_fullpaths(pd, "$s.json")
-
     if isdir(joinpath(_base_path(pd), new_relpath...))
         _any_props(_base_path(pd), _override_base(pd), new_relpath, _validity_sel(pd))
+    elseif isdir(joinpath(_override_base(pd), new_relpath...))
+        _any_props(_override_base(pd), "", new_relpath, _validity_sel(pd))
     elseif ispath(json_primary_filename)
         _check_propery_access(pd, json_primary_filename)
         if ispath(json_override_filename)


### PR DESCRIPTION
This PR allows the `PropsDB` to use properties from overrides paths even in the case when there are no props existing under th `_base_path`. This is in particluar useful for `jlpars` which are disitrbuted via the `jldataprod-overrides` repository and not generated within the `dataflow`