### PR TITLE
Updating the documentation for simulating the electric field and weighting potential of a given detector

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -137,7 +137,12 @@ In addition, when creating a `Simulation`, all simulation functions in SolidStat
 using LegendDataManagement
 using SolidStateDetectors
 
-sim = Simulation(LegendData, "V99000A.yaml", "V99000.yaml")
+T=Float32
+didode_data=LegendDataManagement.readlprops("V99000A.yaml")
+crystal_data=LegendDataManagement.readlprops("V99000.yaml")
+
+
+sim = Simulation{T}(LegendData, diode_data, crystal_data)
 simulate!(sim) # calculate electric field and weighting potentials
 
 using LegendHDF5IO


### PR DESCRIPTION
The instructions written on the extension section of LegendDataManagement did not work for me when I attempted to simulate the electric field and weighting potential of a detector. I had to tweak some parts of the code to get it working. So, I just wanted to open up a discussion about this!