### PR TITLE
Enhanced `read_ldata`

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -96,6 +96,12 @@ dsp = read_ldata(l200, :jldsp, :cal, :p03, :r000, det)
 ```
 In case, a `ChannelId` is missing in a file, the function will throw an `ArgumentError`. To avoid this and return `nothing` instead, you can use the `ignore_missing` keyword argument.
 
+The data can be filtered by a `filterby` keyword argument which is a [PropertyFunction](https://github.com/oschulz/PropertyFunctions.jl/tree/main) applied to each chunk of loaded data:
+```julia
+dsp = read_ldata(l200, :jldsp, :cal, :p03, :r000, ch; filterby=@pf($e_trap > 0.0))
+```
+This will only load data where the `e_trap` property is greater than 0.
+
 It is possible to read in multiple files in parallel using the `Distributed` functionalities from within a session. You can activate parallel read with the `parallel` kwarg.
 ``` julia
 dsp = read_ldata(l200, :jldsp, :cal, DataPeriod(3), ch)

--- a/test/test_ext_legendhdf5io.jl
+++ b/test/test_ext_legendhdf5io.jl
@@ -35,7 +35,7 @@ using TypedTables
         @test read_ldata(l200_lh5, tier, cat, period, run, ch).timestamp == data_fk.timestamp
         @test read_ldata(:timestamp, l200_lh5, tier, cat, period, run, ch).timestamp == data_fk.timestamp
         @test read_ldata((:timestamp, :baseline), l200_lh5, tier, cat, period, run, ch).timestamp == data_fk.timestamp
-        @test read_ldata(@pf($timestamp * $baseline), l200_lh5, tier, cat, period, run, ch) == data_fk.timestamp .* data_fk.baseline
+        @test read_ldata((@pf (; bltime = $timestamp * $baseline, )), l200_lh5, tier, cat, period, run, ch).bltime == data_fk.timestamp .* data_fk.baseline
         @test read_ldata(l200_lh5, tier, fk, ch).timestamp == data_fk.timestamp
         @test read_ldata(l200_lh5, tier, cat, period, run) isa TypedTables.Table
 
@@ -44,9 +44,16 @@ using TypedTables
         @test read_ldata(l200_lh5, tier, cat, period, run, ch; parallel=true).timestamp == data_fk.timestamp
         @test read_ldata(:timestamp, l200_lh5, tier, cat, period, run, ch; parallel=true).timestamp == data_fk.timestamp
         @test read_ldata((:timestamp, :baseline), l200_lh5, tier, cat, period, run, ch; parallel=true).timestamp == data_fk.timestamp
-        @test read_ldata(@pf($timestamp * $baseline), l200_lh5, tier, cat, period, run, ch; parallel=true) == data_fk.timestamp .* data_fk.baseline
+        @test read_ldata((@pf (; bltime = $timestamp * $baseline, )), l200_lh5, tier, cat, period, run, ch; parallel=true).bltime == data_fk.timestamp .* data_fk.baseline
         @test read_ldata(l200_lh5, tier, fk, ch; parallel=true).timestamp == data_fk.timestamp
         @test read_ldata(l200_lh5, tier, cat, period, run; parallel=true) isa TypedTables.Table
+
+        # test filterby
+        @test read_ldata(l200_lh5, tier, cat, period, run, ch; filterby=@pf($daqenergy > 1000)) isa TypedTables.Table
+        @test all(read_ldata(l200_lh5, tier, cat, period, run, ch; filterby=@pf($daqenergy > 1000)).daqenergy .> 1000)
+        @test read_ldata(:timestamp, l200_lh5, tier, cat, period, run, ch; filterby=@pf($daqenergy > 1000)).timestamp == data_fk.timestamp[findall(data_fk.daqenergy .> 1000)]        
+        @test read_ldata((:timestamp, :baseline), l200_lh5, tier, cat, period, run, ch; filterby=@pf($daqenergy > 1000)).timestamp == data_fk.timestamp[findall(data_fk.daqenergy .> 1000)]
+        @test read_ldata((@pf (; bltime = $timestamp * $baseline, )), l200_lh5, tier, cat, period, run, ch; filterby=@pf($daqenergy > 1000)).bltime == data_fk.timestamp[findall(data_fk.daqenergy .> 1000)] .* data_fk.baseline[findall(data_fk.daqenergy .> 1000)]
         
         # test multi run read
         #ToDo: update legend-testdata to make possible


### PR DESCRIPTION
This PR updates the `read_ldata` functionality for enhanced data handling and reading. The following features are implemented:
- Option to filter data while reading with the `filterby` kwarg. This is in particular useful in combination with a `PropertyFunction`
``` julia
dsp = read_ldata(l200, :jldsp, :cal, :p03, :r000, ch; filterby=@pf($e_trap > 0.0))
```
- Speed improvement for single file read
- `ProgressMeter` while reading 
- Bug Fix parallel reading with `WorkerPool` and multiple `DataRun`.
-  Special handling of event-type tiers such as `:jlevt` and `:jlskm` to allow
``` julia
evt = read_ldata(l200, DataTier(:jlevt), :phy, :p03, :r000, ch; filterby=@pf(!$aux.pulser.aux_trig), parallel=true)
```