### PR TITLE
add dataset to LegendData and SetupConfig struct

### DIFF
--- a/src/data_config.jl
+++ b/src/data_config.jl
@@ -23,6 +23,7 @@ data_path(setup, "tier", "raw", "cal", "p02", "r006", "l200-p02-r006-cal-2022122
 """
 struct SetupConfig
     paths::Vector{Pair{Vector{String}, String}}
+    dataset::String
 end
 export SetupConfig
 
@@ -38,7 +39,8 @@ end
 function SetupConfig(p::PropDict)
     paths = [_split_config_pathentry(string(k)) => String(v) for (k,v) in p.paths]
     sorted_paths = sort(paths)
-    SetupConfig(sorted_paths)
+    dataset = haskey(p, :dataset) ? String(p.dataset) : "valid"
+    SetupConfig(sorted_paths, dataset)
 end
 
 

--- a/src/dataprod_config.jl
+++ b/src/dataprod_config.jl
@@ -258,11 +258,12 @@ const _cached_analysis_runs = LRU{Tuple{UInt, DataCategoryLike}, StructVector{@N
 """
     analysis_runs(data::LegendData)
 
-Return cross-period analysis runs.
+Return cross-period analysis runs. Picks the dataset specified in data.dataset.
 """
 function analysis_runs(data::LegendData, cat::DataCategoryLike)
     Table(sort(get!(_cached_analysis_runs, (objectid(data), cat)) do
-        aruns::PropDict = get(data.metadata.datasets.runlists.valid, Symbol(cat), PropDict())
+        haskey(data.metadata.datasets.runlists, Symbol(data.dataset)) || error("Requested dataset '$(data.dataset)' not found in runlists.")
+        aruns::PropDict = get(getproperty(data.metadata.datasets.runlists, Symbol(data.dataset)), Symbol(cat), PropDict())
         periods_and_runs = Vector{@NamedTuple{period::DataPeriod, run::DataRun}}[
             map(run -> (period = DataPeriod(p), run = run), parse_runs(rs))
             for (p, rs) in aruns

--- a/src/legend_data.jl
+++ b/src/legend_data.jl
@@ -55,6 +55,7 @@ struct LegendData <: AbstractSetupData
     # ToDo: Add setup name
     _config::SetupConfig
     _name::Symbol
+    _dataset::Symbol
 end
 export LegendData
 
@@ -67,6 +68,8 @@ get_setup_name(data::LegendData) = getfield(data, :_name)
         getfield(d, :_config)
     elseif s == :name
         getfield(d, :_name)
+    elseif s == :dataset
+        getfield(d, :_dataset)
     elseif s == :metadata
         _ldata_propsdb(d, :metadata)
     elseif s == :tier
@@ -88,7 +91,7 @@ function _ldata_propsdb(d::LegendData, dbsym::Symbol)
 end
 
 @inline function Base.propertynames(d::LegendData)
-    (:metadata, :tier, :par, :jlpar)
+    (:metadata, :tier, :par, :jlpar, :dataset)
 end
 
 @inline function Base.propertynames(d::LegendData, private::Bool)
@@ -96,9 +99,11 @@ end
     private ? (:_config, props...) : props
 end
 
-
-function LegendData(setup::Symbol)
-    LegendData(getproperty(LegendDataConfig().setups, setup), setup)
+function LegendData(setup::Symbol; dataset::Union{AbstractString, Symbol} = "")
+    ldata = getproperty(LegendDataConfig().setups, setup)
+    # Only override if dataset keyword is non-empty
+    selected_dataset = dataset == "" ? Symbol(ldata.dataset) : Symbol(dataset)
+    LegendData(ldata, setup, selected_dataset)
 end
 
 Base.@deprecate data_filename(data::LegendData, filekey::FileKey, tier::DataTierLike) data.tier[tier, filekey]

--- a/src/legend_data.jl
+++ b/src/legend_data.jl
@@ -99,10 +99,10 @@ end
     private ? (:_config, props...) : props
 end
 
-function LegendData(setup::Symbol; dataset::Union{AbstractString, Symbol} = "")
+function LegendData(setup::Symbol; dataset::Symbol = :default)
     ldata = getproperty(LegendDataConfig().setups, setup)
     # Only override if dataset keyword is non-empty
-    selected_dataset = dataset == "" ? Symbol(ldata.dataset) : Symbol(dataset)
+    selected_dataset = dataset == :default ? Symbol(ldata.dataset) : dataset
     LegendData(ldata, setup, selected_dataset)
 end
 

--- a/test/test_legend_data.jl
+++ b/test/test_legend_data.jl
@@ -21,8 +21,14 @@ include("testing_utils.jl")
     @test normalize_path(@inferred(l200.tier[:raw, "l200-p02-r006-cal-20221226T200846Z"])) == "/some/other/storage/raw_lh5/cal/p02/r006/l200-p02-r006-cal-20221226T200846Z-tier_raw.lh5"
     @test normalize_path(@inferred(l200.tier[:dsp, "l200-p02-r006-cal-20221226T200846Z"])) == normalize_path(joinpath(testdata_dir, "generated", "tier", "dsp", "cal", "p02", "r006", "l200-p02-r006-cal-20221226T200846Z-tier_dsp.lh5"))
 
-    props_base_path = data_path(LegendDataConfig().setups.l200, "metadata")
-    @test l200.metadata isa LegendDataManagement.PropsDB
+    @testset "LegendData" begin
+        props_base_path = data_path(LegendDataConfig().setups.l200, "metadata")
+        @test l200.metadata isa LegendDataManagement.PropsDB
+
+        @test l200.dataset == :valid
+        #@test LegendData(:l200_nu24).dataset == :nu24 
+        #@test LegendData(:l200_nu24; dataset = :valid).dataset == :valid
+    end
 
     @testset "channelinfo" begin
         # ToDo: Make type-stable:


### PR DESCRIPTION
I added the discussed functionality to add a dataset to the legend-data-config.

SetupConfig has the field `dataset` that is read from the config file. If no dataset is specified, it defaults to `:valid` as dataset. 
The config dataset can be overwritten during the construction of the LegenData struct by:
`LegendData(:setup ; dataset =  :new_dataset)`

@oschulz is this implementation fine like this?

With this added I changed the `analysis_runs` function to use the dataset specified in LegenData for the used runlist to check for analysis runs.

In the actual runinfo i did not change anything, as I understood the runinfo should always print all general available runs.
Just the is_ana_run is now dependent on the dataset.

I added a test, to check if the overwriting works properly. They are commented out for now, as I need the [PR](https://github.com/legend-exp/legend-testdata/pull/40) to be merged first