### PR TITLE
Remove indent argument from writelprops

### DIFF
--- a/src/lprops.jl
+++ b/src/lprops.jl
@@ -76,17 +76,23 @@ readlprops(filename::AbstractString; trim_null::Bool=false, kwargs...) = _props2
 readlprops(filenames::Vector{<:AbstractString}; trim_null::Bool=false, kwargs...) = _props2lprops(readprops(filenames; trim_null=trim_null, kwargs...))
 
 """
-    writelprops(f::IO, p::PropDict; write_units::Bool=true, write_errors::Bool=true, mutliline::Bool=true)
+    writelprops(f::IO, p::PropDict; multiline::Bool=true)
     writelprops(filename::AbstractString, p::PropDict; multiline::Bool=true)
-    writelprops(db::PropsDB, key::Union{Symbol, DataSelector}, p::PropDict; kwargs...)
+    writelprops(db::MaybePropsDB, key::Union{Symbol, DataSelector}, p::PropDict; kwargs...)
 
 Write a PropDict to a file and strip it to `:val` and `:unit` fields and `:val` and `:err` fields.
 """
 function writelprops end
 export writelprops
 
-writelprops(io::IO, p::PropDict; multiline::Bool = true) = writeprops(io, _lprops2props(p); multiline=multiline)
-writelprops(filename::AbstractString, p::PropDict; multiline::Bool = true) = writeprops(filename, _lprops2props(p); multiline=multiline)
+function writelprops(io::IO, p::PropDict; multiline::Bool = true, indent::Union{Int,Nothing} = nothing)
+    indent !== nothing && Base.depwarn("`indent` keyword argument to `writelprops` is deprecated and will be ignored", :writelprops)
+    writeprops(io, _lprops2props(p); multiline=multiline)
+end
+function writelprops(filename::AbstractString, p::PropDict; multiline::Bool = true, indent::Union{Int,Nothing} = nothing)
+    indent !== nothing && Base.depwarn("`indent` keyword argument to `writelprops` is deprecated and will be ignored", :writelprops)
+    writeprops(filename, _lprops2props(p); multiline=multiline)
+end
 
 writelprops(db::MaybePropsDB, key::Union{Symbol, DataSelector}, p::PropDict; kwargs...) = writelprops(joinpath(mkpath(data_path(db)), "$(string(key)).yaml"), p; kwargs...)
 

--- a/src/lprops.jl
+++ b/src/lprops.jl
@@ -76,8 +76,8 @@ readlprops(filename::AbstractString; trim_null::Bool=false, kwargs...) = _props2
 readlprops(filenames::Vector{<:AbstractString}; trim_null::Bool=false, kwargs...) = _props2lprops(readprops(filenames; trim_null=trim_null, kwargs...))
 
 """
-    writelprops(f::IO, p::PropDict; write_units::Bool=true, write_errors::Bool=true, mutliline::Bool=true, indent::Int=4)
-    writelprops(filename::AbstractString, p::PropDict; multiline::Bool=true, indent::Int=4)
+    writelprops(f::IO, p::PropDict; write_units::Bool=true, write_errors::Bool=true, mutliline::Bool=true)
+    writelprops(filename::AbstractString, p::PropDict; multiline::Bool=true)
     writelprops(db::PropsDB, key::Union{Symbol, DataSelector}, p::PropDict; kwargs...)
 
 Write a PropDict to a file and strip it to `:val` and `:unit` fields and `:val` and `:err` fields.
@@ -85,8 +85,8 @@ Write a PropDict to a file and strip it to `:val` and `:unit` fields and `:val` 
 function writelprops end
 export writelprops
 
-writelprops(io::IO, p::PropDict; multiline::Bool = true, indent::Int = 4) = writeprops(io, _lprops2props(p); multiline=multiline, indent=indent)
-writelprops(filename::AbstractString, p::PropDict; multiline::Bool = true, indent::Int = 4) = writeprops(filename, _lprops2props(p); multiline=multiline, indent=indent)
+writelprops(io::IO, p::PropDict; multiline::Bool = true) = writeprops(io, _lprops2props(p); multiline=multiline)
+writelprops(filename::AbstractString, p::PropDict; multiline::Bool = true) = writeprops(filename, _lprops2props(p); multiline=multiline)
 
 writelprops(db::MaybePropsDB, key::Union{Symbol, DataSelector}, p::PropDict; kwargs...) = writelprops(joinpath(mkpath(data_path(db)), "$(string(key)).yaml"), p; kwargs...)
 

--- a/src/lprops.jl
+++ b/src/lprops.jl
@@ -88,7 +88,7 @@ export writelprops
 writelprops(io::IO, p::PropDict; multiline::Bool = true) = writeprops(io, _lprops2props(p); multiline=multiline)
 writelprops(filename::AbstractString, p::PropDict; multiline::Bool = true) = writeprops(filename, _lprops2props(p); multiline=multiline)
 
-function writelprops(f::Union{IO, AbstractString}, p::PropDict; indent::Int, kwargs...)
+function writelprops(f, p; indent::Int, kwargs...)
     Base.depwarn("`indent` keyword argument to `writelprops` is deprecated and will be ignored", :writelprops)
     writelprops(f, p; kwargs...)
 end

--- a/src/lprops.jl
+++ b/src/lprops.jl
@@ -85,13 +85,12 @@ Write a PropDict to a file and strip it to `:val` and `:unit` fields and `:val` 
 function writelprops end
 export writelprops
 
-function writelprops(io::IO, p::PropDict; multiline::Bool = true, indent::Union{Int,Nothing} = nothing)
-    indent !== nothing && Base.depwarn("`indent` keyword argument to `writelprops` is deprecated and will be ignored", :writelprops)
-    writeprops(io, _lprops2props(p); multiline=multiline)
-end
-function writelprops(filename::AbstractString, p::PropDict; multiline::Bool = true, indent::Union{Int,Nothing} = nothing)
-    indent !== nothing && Base.depwarn("`indent` keyword argument to `writelprops` is deprecated and will be ignored", :writelprops)
-    writeprops(filename, _lprops2props(p); multiline=multiline)
+writelprops(io::IO, p::PropDict; multiline::Bool = true) = writeprops(io, _lprops2props(p); multiline=multiline)
+writelprops(filename::AbstractString, p::PropDict; multiline::Bool = true) = writeprops(filename, _lprops2props(p); multiline=multiline)
+
+function writelprops(f::Union{IO, AbstractString}, p::PropDict; indent::Int, kwargs...)
+    Base.depwarn("`indent` keyword argument to `writelprops` is deprecated and will be ignored", :writelprops)
+    writelprops(f, p; kwargs...)
 end
 
 writelprops(db::MaybePropsDB, key::Union{Symbol, DataSelector}, p::PropDict; kwargs...) = writelprops(joinpath(mkpath(data_path(db)), "$(string(key)).yaml"), p; kwargs...)


### PR DESCRIPTION
Drop the indent keyword argument from writelprops. This is not compatible with YAML (only indent::Int=4), but you can completely leave it out as @oschulz suggested. 