### PR TITLE
Change to detector ID based jlevt reading in read_ldata

### DIFF
--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -237,63 +237,56 @@ function _index_col(col, det_idxs, trig_idxs, det_inner_lens, trig_inner_lens)
     end
 end
 
-# Read an event-tier table. With `det = nothing`, every column is materialized
-# in its native shape (event-scalar or VoV) under the prefix-flattened name.
-# With `det` given, only events where the detector is present are kept:
-# the mask comes from `trig_e_det` when available (for systems with a
-# per-trigger view, e.g. GEDs in jlevt) or `detector` otherwise (SPMs in
-# jlevt, PMTs in jlpmt). For surviving events, per-det-list and per-trigger
-# VoV columns are unwrapped at the detector's respective index. Other
-# subgroup columns (`ged_spm_*`, `aux_pulser_*`, …) remain event-scalar and
-# are masked alongside.
+# Read an event-tier table for a single detector. Only events where the
+# detector is present are kept: the mask comes from `trig_e_det` when
+# available (for systems with a per-trigger view, e.g. GEDs in jlevt) or
+# `detector` otherwise (SPMs in jlevt, PMTs in jlpmt). For surviving events,
+# per-det-list and per-trigger VoV columns are unwrapped at the detector's
+# respective index. Other subgroup columns (`ged_spm_*`, `aux_pulser_*`, …)
+# remain event-scalar and are masked alongside.
 function _read_evt_table(h::LegendHDF5IO.LHDataStore, data::LegendData, filekey::FileKey,
-        tier::DataTier, det::Union{DetectorId,Nothing}, f::Base.Callable,
+        tier::DataTier, det::DetectorId, f::Base.Callable,
         filterby::Base.Callable, n_evts::Int)
 
     nmap = _build_evt_namemap(h, tier)
 
-    persubdet_path = nothing
+    sys = channelinfo(data, filekey, det).system
+    persubdet_path = _evt_persubdet_path(tier, sys)
+    persubdet_path === nothing &&
+        error("read_ldata(:$tier, ..., $det): no per-det data in $tier for system :$sys")
+    haskey(h, persubdet_path) ||
+        error("read_ldata(:$tier, ..., $det): /$persubdet_path missing in file")
+    psd = h[persubdet_path]
+
+    # Find the detector's per-event position in `trig_e_det` (preferred,
+    # exists for GED-like systems) or `detector` (fallback for SPMs/PMTs).
+    # The chosen list also drives the event mask: events where the detector
+    # did not trigger / is not in the array are dropped.
     mask = nothing
     det_idxs = trig_idxs = nothing
     det_inner_lens = trig_inner_lens = nothing
-    if det !== nothing
-        sys = channelinfo(data, filekey, det).system
-        persubdet_path = _evt_persubdet_path(tier, sys)
-        persubdet_path === nothing &&
-            error("read_ldata(:$tier, ..., $det): no per-det data in $tier for system :$sys")
-        haskey(h, persubdet_path) ||
-            error("read_ldata(:$tier, ..., $det): /$persubdet_path missing in file")
-        psd = h[persubdet_path]
-
-        # Find the detector's per-event position in `trig_e_det` (preferred,
-        # exists for GED-like systems) or `detector` (fallback for SPMs/PMTs).
-        # The chosen list also drives the event mask: events where the
-        # detector did not trigger / is not in the array are dropped.
-        if hasproperty(psd, :trig_e_det)
-            tl = getproperty(psd, :trig_e_det)[:]
-            keep = [findfirst(isequal(det), t) for t in tl]
-            mask = .!isnothing.(keep)
-            trig_idxs = Int.(keep[mask])
-            trig_inner_lens = length.(tl[mask])
-        end
-        if hasproperty(psd, :detector)
-            dl = getproperty(psd, :detector)[:]
-            keep = [findfirst(isequal(det), t) for t in dl]
-            mask === nothing && (mask = .!isnothing.(keep))
-            det_idxs = Int.(keep[mask])
-            det_inner_lens = length.(dl[mask])
-        end
-        mask === nothing &&
-            error("read_ldata(:$tier, ..., $det): /$persubdet_path has neither :detector nor :trig_e_det")
+    if hasproperty(psd, :trig_e_det)
+        tl = getproperty(psd, :trig_e_det)[:]
+        keep = [findfirst(isequal(det), t) for t in tl]
+        mask = .!isnothing.(keep)
+        trig_idxs = Int.(keep[mask])
+        trig_inner_lens = length.(tl[mask])
     end
+    if hasproperty(psd, :detector)
+        dl = getproperty(psd, :detector)[:]
+        keep = [findfirst(isequal(det), t) for t in dl]
+        mask === nothing && (mask = .!isnothing.(keep))
+        det_idxs = Int.(keep[mask])
+        det_inner_lens = length.(dl[mask])
+    end
+    mask === nothing &&
+        error("read_ldata(:$tier, ..., $det): /$persubdet_path has neither :detector nor :trig_e_det")
 
     function load_col(name::Symbol)
         haskey(nmap, name) ||
             error("column $name not found in /$tier (available: $(sort(collect(keys(nmap)))))")
         (path, col) = nmap[name]
-        raw = getproperty(h[path], col)[:]
-        mask === nothing && return raw
-        masked = raw[mask]
+        masked = getproperty(h[path], col)[:][mask]
         path == persubdet_path ? _index_col(masked, det_idxs, trig_idxs, det_inner_lens, trig_inner_lens) : masked
     end
 
@@ -333,6 +326,10 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
 
     _lh5_data_open(data, tier, filekey, det_arg) do h
         if tier in _evt_tiers
+            # No detector: return the native nested LH5 structure (e.g.
+            # `evt_data.aux.forcedtrigger.aux_trig`). Per-detector reads use
+            # the flat-prefixed table from `_read_evt_table` instead.
+            has_det || return _apply_read(h["$tier"], f, filterby, n_evts)
             _read_evt_table(h, data, filekey, tier, det_arg, f, filterby, n_evts)
         else
             has_det || throw(ArgumentError("DetectorId required for tier $tier"))

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -115,18 +115,17 @@ function __init__()
     (@isdefined DataCategory) && extend_datatype_dict(DataCategory, "datacategory")
     (@isdefined Timestamp) && extend_datatype_dict(Timestamp, "timestamp")
     (@isdefined FileKey) && extend_datatype_dict(FileKey, "filekey")
-    (@isdefined ChannelId) && extend_datatype_dict(ChannelId, "channelid")
     (@isdefined DetectorId) && extend_datatype_dict(DetectorId, "detectorid")
     (@isdefined DataPartition) && extend_datatype_dict(DataPartition, "datapartition")
 end
 
-# Open a tier/filekey LH5 file. Prefers a global tier file (DetID inside);
-# falls back to a legacy per-detector file when requested.
+const _evt_tiers = DataTier.([:jlevt, :jlskm])
+const _perdet_tiers = DataTier.([:jlpeaks, :jlhit, :jlpls])
+
+# Open the LH5 file for a given tier/filekey (+det for per-detector tiers).
 function _lh5_data_open(f::Function, data::LegendData, tier::DataTierLike, filekey::FileKey, det::DetectorIdLike=DetectorId(""), mode::AbstractString="r")
-    filename = try data.tier[DataTier(tier), filekey] catch; "" end
-    det_filename = isempty(string(det)) ? "" : try data.tier[DataTier(tier), filekey, det] catch; "" end
-    path = isfile(filename) ? filename : isfile(det_filename) ? det_filename : throw(ArgumentError("Neither $(basename(filename)) nor $(basename(det_filename)) exists"))
-    @debug "Read from $(basename(path))"
+    t = DataTier(tier)
+    path = t in _perdet_tiers ? data.tier[t, filekey, DetectorId(det)] : data.tier[t, filekey]
     LegendHDF5IO.lh5open(f, path, mode)
 end
 
@@ -141,8 +140,6 @@ _load_all_keys(nt::NamedTuple, n_evts::Int=-1) = if length(nt) == 1 _load_all_ke
 _load_all_keys(arr::AbstractArray, n_evts::Int=-1) = arr[:][if (n_evts < 1 || n_evts > length(arr)) 1:length(arr) else rand(1:length(arr), n_evts) end]
 _load_all_keys(t::Table, n_evts::Int=-1) = t[:][if (n_evts < 1 || n_evts > length(t)) 1:length(t) else rand(1:length(t), n_evts) end]
 _load_all_keys(x, n_evts::Int=-1) = x
-
-const _evt_tiers = DataTier.([:jlevt, :jlskm])
 
 # Apply PropSelFunction / filter / function to a loaded HDF5 node, return a Table or array
 function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::Int)
@@ -255,9 +252,11 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
 end
 
 function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPeriod, DataRun, DetectorIdLike}; kwargs...)
-    fks = search_disk(FileKey, data.tier[rsel[1], rsel[2], rsel[3], rsel[4]])
+    tier = DataTier(rsel[1])
+    tier in _perdet_tiers && return LegendDataManagement.read_ldata(f, data, (tier, start_filekey(data, (rsel[3], rsel[4], rsel[2])), rsel[5]); kwargs...)
+    fks = search_disk(FileKey, data.tier[tier, rsel[2], rsel[3], rsel[4]])
     isempty(fks) && throw(ArgumentError("No filekeys found for $(rsel[2]) $(rsel[3]) $(rsel[4])"))
-    LegendDataManagement.read_ldata(f, data, (rsel[1], fks, rsel[5]); kwargs...)
+    LegendDataManagement.read_ldata(f, data, (tier, fks, rsel[5]); kwargs...)
 end
 
 

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -223,8 +223,7 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
         end
     end
     if tier in _evt_tiers && !isempty(string(det))
-        ch = _get_channelid(data, filekey, det)
-        data_tier[any.(map.(isequal(Int(ch)), data_tier.geds.trig_e_ch))]
+        data_tier[any.(map.(isequal(det), data_tier.geds.trig_e_det))]
     else
         data_tier
     end

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -2,7 +2,6 @@ module LegendDataManagementLegendHDF5IOExt
 
 using LegendDataManagement
 LegendDataManagement._lh5_ext_loaded(::Val{true}) = true
-using LegendDataManagement.LDMUtils: detector2channel, channel2detector
 using LegendDataManagement: RunCategorySelLike
 using LegendHDF5IO
 using LegendDataTypes: fast_flatten, flatten_by_key
@@ -10,38 +9,8 @@ using StructArrays
 using TypedTables, PropertyFunctions
 using Distributed, ProgressMeter
 
-const ChannelOrDetectorIdLike = Union{ChannelIdLike, DetectorIdLike}
-const AbstractDataSelectorLike = Union{AbstractString, Symbol, DataTierLike, DataCategoryLike, DataPeriodLike, DataRunLike, DataPartitionLike, ChannelOrDetectorIdLike}
-const PossibleDataSelectors = [DataTier, DataCategory, DataPeriod, DataRun, DataPartition, ChannelId, DetectorId]
-
-function _is_valid_id_or_tier(data::LegendData, rsel::Union{AnyValiditySelection, RunCategorySelLike}, id::ChannelOrDetectorIdLike)
-    if LegendDataManagement._can_convert_to(ChannelId, id) ||  LegendDataManagement._can_convert_to(DetectorId, id) ||  LegendDataManagement._can_convert_to(DataTier, id)
-        true  
-    else  
-        @warn "Skipped $id since it is neither a valid `ChannelId`, `DetectorId` nor a `DataTier`"  
-        false  
-    end  
-end
-
-function _get_channelid(data::LegendData, rsel::Union{AnyValiditySelection, RunCategorySelLike}, det::ChannelOrDetectorIdLike)
-    if LegendDataManagement._can_convert_to(ChannelId, det)
-        ChannelId(det)
-    elseif LegendDataManagement._can_convert_to(DetectorId, det)
-        detector2channel(data, rsel, det)
-    else
-        throw(ArgumentError("$det is neither a ChannelId nor a DetectorId"))
-    end
-end
-
-function _get_detectorid(data::LegendData, rsel::Union{AnyValiditySelection, RunCategorySelLike}, det::ChannelOrDetectorIdLike)
-    if LegendDataManagement._can_convert_to(DetectorId, det)
-        DetectorId(det)
-    elseif LegendDataManagement._can_convert_to(ChannelId, det)
-        channel2detector(data, rsel, det)
-    else
-        throw(ArgumentError("$det is neither a ChannelId nor a DetectorId"))
-    end
-end
+const AbstractDataSelectorLike = Union{AbstractString, Symbol, DataTierLike, DataCategoryLike, DataPeriodLike, DataRunLike, DataPartitionLike, DetectorIdLike}
+const PossibleDataSelectors = [DataTier, DataCategory, DataPeriod, DataRun, DataPartition, DetectorId]
 
 
 const dataselector_bytypes = Dict{Type, String}()
@@ -151,18 +120,14 @@ function __init__()
     (@isdefined DataPartition) && extend_datatype_dict(DataPartition, "datapartition")
 end
 
-function _lh5_data_open(f::Function, data::LegendData, tier::DataTierLike, filekey::FileKey, det::DetectorIdLike, mode::AbstractString="r")
-    det_filename = data.tier[DataTier(tier), filekey, det]
-    filename = data.tier[DataTier(tier), filekey]
-    if isfile(det_filename)
-        @debug "Read from $(basename(det_filename))"
-        LegendHDF5IO.lh5open(f, det_filename, mode)
-    elseif isfile(filename)
-        @debug "Read from $(basename(filename))"
-        LegendHDF5IO.lh5open(f, filename, mode)
-    else
-        throw(ArgumentError("Neither $(basename(filename)) nor $(basename(det_filename)) found"))
-    end
+# Open a tier/filekey LH5 file. Prefers a global tier file (DetID inside);
+# falls back to a legacy per-detector file when requested.
+function _lh5_data_open(f::Function, data::LegendData, tier::DataTierLike, filekey::FileKey, det::DetectorIdLike=DetectorId(""), mode::AbstractString="r")
+    filename = try data.tier[DataTier(tier), filekey] catch; "" end
+    det_filename = isempty(string(det)) ? "" : try data.tier[DataTier(tier), filekey, det] catch; "" end
+    path = isfile(filename) ? filename : isfile(det_filename) ? det_filename : throw(ArgumentError("Neither $(basename(filename)) nor $(basename(det_filename)) exists"))
+    @debug "Read from $(basename(path))"
+    LegendHDF5IO.lh5open(f, path, mode)
 end
 
 _skipnothingmissing(xv::AbstractVector) = [x for x in skipmissing(xv) if !isnothing(x)]
@@ -179,80 +144,71 @@ _load_all_keys(x, n_evts::Int=-1) = x
 
 const _evt_tiers = DataTier.([:jlevt, :jlskm])
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey, ChannelOrDetectorIdLike}; filterby::Base.Callable=Returns(true), filtertier::DataTierLike=first(rsel), n_evts::Int=-1, ignore_missing::Bool=false, parallel::Bool=false, wpool::WorkerPool=default_worker_pool())
-    tier, filekey = DataTier(rsel[1]), rsel[2]
-
-    det = if !isempty(string((rsel[3])))
-            _get_detectorid(data, rsel[2], rsel[3])
+# Apply PropSelFunction / filter / function to a loaded HDF5 node, return a Table or array
+function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::Int)
+    if f isa PropSelFunction && filterby == Returns(true)
+        src_cols = _propfunc_src_columnnames(f)
+        trg_cols = _propfunc_trg_columnnames(f)
+        Table(if length(src_cols) == 1
+            NamedTuple{trg_cols}([_load_all_keys(getproperty(only(src_cols))(h_node), n_evts)])
         else
-            rsel[3]
-    end
-    det_tier = tier in _evt_tiers ? "/$tier" : "$det/$tier"
-    
-    data_tier = _lh5_data_open(data, tier, filekey, det) do h
-        if !isempty(string(det)) && !(tier in _evt_tiers) && !haskey(h, "$det")
-            if ignore_missing
-                @warn "Detector $det not found in $(basename(string(h.data_store)))"
-                return nothing
-            else
-                throw(ArgumentError("Detector $det not found in $(basename(string(h.data_store)))"))
-            end
-        end
-        
-        # load detector data
-        if f isa PropSelFunction && filterby == Returns(true)
-            # if no filter given optimize performance for property selection functions by only loading required columns
-            Table(if length(_propfunc_src_columnnames(f)) == 1
-                NamedTuple{_propfunc_trg_columnnames(f)}([_load_all_keys(getproperty(only(_propfunc_src_columnnames(f)))(h[det_tier]), n_evts)])
-            else
-                NamedTuple{_propfunc_trg_columnnames(f)}(Tuple(values(columns(_load_all_keys(getproperties(_propfunc_src_columnnames(f))(h[det_tier]), n_evts)))))
-            end)
-        else
-            lh5_data = _load_all_keys(h[det_tier], n_evts)
-            if filterby != Returns(true)
-                lh5_data = lh5_data |> PropertyFunctions.filterby(filterby)
-            end
-            if f != identity
-                lh5_data = f.(lh5_data)
-            end
-            if TypedTables.Tables.istable(lh5_data)
-                Table(lh5_data)
-            else
-                lh5_data
-            end
-        end
-    end
-    if tier in _evt_tiers && !isempty(string(det))
-        data_tier[any.(map.(isequal(det), data_tier.geds.trig_e_det))]
+            NamedTuple{trg_cols}(Tuple(values(columns(_load_all_keys(getproperties(src_cols)(h_node), n_evts)))))
+        end)
     else
-        data_tier
+        lh5_data = _load_all_keys(h_node, n_evts)
+        filterby != Returns(true) && (lh5_data = lh5_data |> PropertyFunctions.filterby(filterby))
+        f != identity && (lh5_data = f.(lh5_data))
+        TypedTables.Tables.istable(lh5_data) ? Table(lh5_data) : lh5_data
+    end
+end
+
+# Per-detector read from an event-tier file: filter events where `det` triggered and
+# apply `f` (PropSelFunction targets columns in jlevt/geds by default).
+function _read_evt_perdet(h, tier::DataTier, det::DetectorId, f::Base.Callable, filterby::Base.Callable, n_evts::Int)
+    mask = any.(isequal(det), h["$tier/geds/trig_e_det"][:])
+    geds = _apply_read(h["$tier/geds"], f, filterby, -1)
+    geds[mask]
+end
+
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey, DetectorIdLike}; filterby::Base.Callable=Returns(true), n_evts::Int=-1, ignore_missing::Bool=false, kwargs...)
+    tier, filekey = DataTier(rsel[1]), rsel[2]
+    has_det = !isempty(string(rsel[3]))
+    det_arg = has_det ? DetectorId(rsel[3]) : DetectorId("")
+
+    _lh5_data_open(data, tier, filekey, det_arg) do h
+        if tier in _evt_tiers
+            has_det || return _apply_read(h["$tier"], f, filterby, n_evts)
+            _read_evt_perdet(h, tier, det_arg, f, filterby, n_evts)
+        else
+            has_det || throw(ArgumentError("DetectorId required for tier $tier"))
+            path = haskey(h, "$tier/$det_arg") ? "$tier/$det_arg" : "$tier"
+            if !haskey(h, path)
+                ignore_missing && (@warn "Detector $det_arg not found in $(basename(string(h.data_store)))"; return nothing)
+                throw(ArgumentError("Detector $det_arg not found in $(basename(string(h.data_store)))"))
+            end
+            _apply_read(h[path], f, filterby, n_evts)
+        end
     end
 end
 
 function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey}; kwargs...)
-    ids = _lh5_data_open(data, rsel[1], rsel[2], "") do h
-        keys(h)
+    tier = DataTier(rsel[1])
+    tier in _evt_tiers && return LegendDataManagement.read_ldata(f, data, (tier, rsel[2], ""); kwargs...)
+    dets = _lh5_data_open(data, tier, rsel[2]) do h
+        haskey(h, "$tier") ? collect(keys(h["$tier"])) : String[]
     end
-    ids = filter(x -> _is_valid_id_or_tier(data, rsel[2], x), ids)
-    @debug "Found keys: $ids"
-    if length(ids) == 1
-        if string(only(ids)) == string(rsel[1])
-            LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], ""); kwargs...)
-        elseif LegendDataManagement._can_convert_to(ChannelId, only(ids)) || LegendDataManagement._can_convert_to(DetectorId, only(ids))
-            LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], string(only(ids))); kwargs...)
-        else
-            throw(ArgumentError("No tier channel or detector found in $(basename(string(h.data_store)))"))
-        end
+    isempty(dets) && throw(ArgumentError("No detectors found under /$tier in $(basename(data.tier[tier, rsel[2]]))"))
+    if length(dets) == 1
+        LegendDataManagement.read_ldata(f, data, (tier, rsel[2], only(dets)); kwargs...)
     else
-        NamedTuple{Tuple(Symbol.(ids))}([LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], ch); kwargs...) for ch in ids])
+        NamedTuple{Tuple(Symbol.(dets))}([LegendDataManagement.read_ldata(f, data, (tier, rsel[2], d); kwargs...) for d in dets])
     end
 end
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, AbstractVector{FileKey}, ChannelOrDetectorIdLike}; parallel::Bool=false, wpool::WorkerPool=default_worker_pool(), kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, AbstractVector{FileKey}, DetectorIdLike}; parallel::Bool=false, wpool::WorkerPool=default_worker_pool(), kwargs...)
     first_fk = first(rsel[2])
     p = Progress(length(rsel[2]), desc="Reading from $(first_fk.setup)-$(first_fk.period)-$(first_fk.run)-$(first_fk.category)", showspeed=true)
     lflatten(if parallel
-                # TODO: Check if wpool is connected via :master_worker if myid() != 1
                 @debug "Parallel read with $(length(workers())) workers from $(length(rsel[2])) filekeys"
                 progress_pmap(wpool, rsel[2]; progress=p) do fk
                     LegendDataManagement.read_ldata(f, data, ifelse(!isempty(string(rsel[3])), (rsel[1], fk, rsel[3]),  (rsel[1], fk)); kwargs...)
@@ -293,42 +249,26 @@ LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{
     LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], rsel[3], rsel[4], ""); kwargs...)
 
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPartition, ChannelOrDetectorIdLike}; kwargs...)
-    first_run = first(LegendDataManagement._get_partitions(data, :default, rsel[2])[rsel[3]])
-    ch = _get_channelid(data, (first_run.period, first_run.run, rsel[2]), rsel[4])
-    pinfo = partitioninfo(data, ch, rsel[3])
-    @assert ch == _get_channelid(data, (first(pinfo).period, first(pinfo).run, rsel[2]), rsel[4]) "Channel mismatch in partitioninfo"
-    LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], pinfo, ch); kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPartition, DetectorIdLike}; kwargs...)
+    pinfo = partitioninfo(data, DetectorId(rsel[4]), rsel[3])
+    LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], pinfo, rsel[4]); kwargs...)
 end
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPeriod, ChannelOrDetectorIdLike}; kwargs...)
-    rinfo = runinfo(data, rsel[3])
-    first_run = first(rinfo)
-    ch = if !isempty(string(rsel[4]))
-        _get_channelid(data, (first_run.period, first_run.run, rsel[2]), rsel[4])
-    else
-        string(rsel[4])
-    end
-    LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], rinfo, ch); kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPeriod, DetectorIdLike}; kwargs...)
+    LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], runinfo(data, rsel[3]), rsel[4]); kwargs...)
 end
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPeriod, DataRun, ChannelOrDetectorIdLike}; kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPeriod, DataRun, DetectorIdLike}; kwargs...)
     fks = search_disk(FileKey, data.tier[rsel[1], rsel[2], rsel[3], rsel[4]])
-    ch = rsel[5]
-    if isempty(fks) && isfile(data.tier[rsel[1:4]..., ch])
-        LegendDataManagement.read_ldata(f, data, (rsel[1], start_filekey(data, (rsel[3], rsel[4], rsel[2])), ch); kwargs...)
-    elseif !isempty(fks)
-        LegendDataManagement.read_ldata(f, data, (rsel[1], fks, ch); kwargs...)
-    else
-        throw(ArgumentError("No filekeys found for $(rsel[2]) $(rsel[3]) $(rsel[4])"))
-    end
+    isempty(fks) && throw(ArgumentError("No filekeys found for $(rsel[2]) $(rsel[3]) $(rsel[4])"))
+    LegendDataManagement.read_ldata(f, data, (rsel[1], fks, rsel[5]); kwargs...)
 end
 
 
 ### DataPartition
 const _partinfo_required_cols = NamedTuple{(:period, :run), Tuple{DataPeriod, DataRun}}
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, DataCategoryLike, Table{_partinfo_required_cols}, ChannelOrDetectorIdLike}; parallel::Bool=false, wpool::WorkerPool=default_worker_pool(), kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, DataCategoryLike, Table{_partinfo_required_cols}, DetectorIdLike}; parallel::Bool=false, wpool::WorkerPool=default_worker_pool(), kwargs...)
     p = Progress(length(rsel[3]), desc="Reading from $(length(rsel[3])) runs", showspeed=true)
     lflatten(if parallel
                 # TODO: Check if wpool is connected via :master_worker if myid() != 1
@@ -347,7 +287,7 @@ end
 LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, DataCategoryLike, Table{_partinfo_required_cols}}; kwargs...) =
     LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], rsel[3], ""); kwargs...)
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, DataCategoryLike, Table, ChannelOrDetectorIdLike}; kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, DataCategoryLike, Table, DetectorIdLike}; kwargs...)
     @assert (hasproperty(rsel[3], :period) && hasproperty(rsel[3], :run)) "Runtable doesn't provide periods and runs"
     LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], Table(period = rsel[3].period, run = rsel[3].run), rsel[4]); kwargs...)
 end

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -173,16 +173,24 @@ end
 # `filterby` can combine per-det and event-global flags. Fast path: when called
 # with a PropSelFunction and a PropertyFunction filterby, only the columns
 # referenced by their src tuples are materialized.
-_unwrap_perdet(col::AbstractVector{<:AbstractVector}, idxs::Vector{Int}) = getindex.(col, idxs)
-_unwrap_perdet(col::AbstractVector, ::Vector{Int}) = col
+# jlevt/geds uses two VoV indexing schemes per event:
+#   - per-trigger    (length == #triggers, e.g. trig_e_*)            → use trig_idxs
+#   - per-det-list   (length == #all_dets_in_array, e.g. e_cusp_*)   → use det_idxs
+# Decision is per-row by inner-vector length so SPMs (only per-trigger) and
+# GEDs (mixed) both work without a hardcoded column list.
+_unwrap_perdet(col::AbstractVector, _, _, _) = col
+function _unwrap_perdet(col::AbstractVector{<:AbstractVector}, trig_idxs::Vector{Int}, det_idxs::Vector{Int}, n_trig::Vector{Int})
+    [length(col[k]) == n_trig[k] ? col[k][trig_idxs[k]] : col[k][det_idxs[k]] for k in eachindex(col)]
+end
 
 const _evt_scalar_subgroups = ("ged_spm", "ft_spm", "ged_pmt")
 
 # Load one named column from the right subgroup. Per-det subgroup cols are
-# VoV-unwrapped at `idxs`; event-scalar and aux cols are masked only.
-function _load_perdet_col(h, tier::DataTier, persubdet, col::Symbol, mask::AbstractVector{Bool}, idxs::Vector{Int})
+# VoV-unwrapped using trig_idxs OR det_idxs (chosen per-row by length, see
+# `_unwrap_perdet`); event-scalar and aux cols are masked only.
+function _load_perdet_col(h, tier::DataTier, persubdet, col::Symbol, mask::AbstractVector{Bool}, trig_idxs::Vector{Int}, det_idxs::Vector{Int}, n_trig::Vector{Int})
     if col in propertynames(persubdet)
-        return _unwrap_perdet(getproperty(persubdet, col)[mask], idxs)
+        return _unwrap_perdet(getproperty(persubdet, col)[mask], trig_idxs, det_idxs, n_trig)
     end
     for g in _evt_scalar_subgroups
         haskey(h, "$tier/$g") || continue
@@ -214,9 +222,20 @@ function _read_evt_perdet(h, data::LegendData, filekey::FileKey, tier::DataTier,
         error("read_ldata(:$tier, ..., $det): no per-det data in $tier for system :$system")
     end
     persubdet = h["$tier/$subgrp"]
-    keep = [findfirst(isequal(det), t) for t in getproperty(persubdet, mask_col)[:]]
+    trig_list = getproperty(persubdet, mask_col)[:]
+    keep = [findfirst(isequal(det), t) for t in trig_list]
     mask = .!isnothing.(keep)
-    idxs = Int.(keep[mask])
+    trig_idxs = Int.(keep[mask])
+    n_trig    = length.(trig_list[mask])
+    # det-list position (e.g. for /jlevt/geds/e_cusp_ctc_cal which is indexed
+    # by the all-dets-in-array list, not by trigger position). Falls back to
+    # trig_idxs for systems / files without trig_e_det_idxs (SPMs etc.).
+    det_idxs = if hasproperty(persubdet, :trig_e_det_idxs)
+        di = getproperty(persubdet, :trig_e_det_idxs)[mask]
+        [Int(di[k][trig_idxs[k]]) for k in eachindex(trig_idxs)]
+    else
+        trig_idxs
+    end
 
     # Fast path: lazy load only the columns needed by PropSel + filterby
     if f isa PropSelFunction && (filterby isa PropertyFunctions.PropertyFunction || filterby === Returns(true))
@@ -224,7 +243,7 @@ function _read_evt_perdet(h, data::LegendData, filekey::FileKey, tier::DataTier,
         trg_cols = _propfunc_trg_columnnames(f)
         filt_cols = _propfunc_src_columnnames(filterby)
         needed = Tuple(unique((src_cols..., filt_cols...)))
-        cols = map(c -> _load_perdet_col(h, tier, persubdet, c, mask, idxs), needed)
+        cols = map(c -> _load_perdet_col(h, tier, persubdet, c, mask, trig_idxs, det_idxs, n_trig), needed)
         tbl = Table(NamedTuple{needed}(cols))
         filt_tbl = filterby === Returns(true) ? tbl : (tbl |> PropertyFunctions.filterby(filterby))
         n_evts > 0 && (filt_tbl = filt_tbl[1:min(n_evts, length(filt_tbl))])
@@ -234,7 +253,7 @@ function _read_evt_perdet(h, data::LegendData, filekey::FileKey, tier::DataTier,
 
     # Eager fallback: build full merged table
     col_names = propertynames(persubdet)
-    cols = map(c -> _unwrap_perdet(getproperty(persubdet, c)[mask], idxs), col_names)
+    cols = map(c -> _unwrap_perdet(getproperty(persubdet, c)[mask], trig_idxs, det_idxs, n_trig), col_names)
     nt = NamedTuple{col_names}(cols)
     for g in _evt_scalar_subgroups
         haskey(h, "$tier/$g") || continue
@@ -256,7 +275,16 @@ function _read_evt_perdet(h, data::LegendData, filekey::FileKey, tier::DataTier,
     _apply_read(Table(nt), f, filterby, n_evts)
 end
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey, DetectorIdLike}; filterby::Base.Callable=Returns(true), n_evts::Int=-1, ignore_missing::Bool=false, kwargs...)
+# Resolve the inner HDF5 path for (tier, det). Primary: "tier/det". Legacy
+# fallback: "det/tier" — Returns `nothing` if neither layout is present.
+function _resolve_perdet_path(h, tier::DataTier, det::DetectorId)
+    haskey(h, "$tier/$det") && return "$tier/$det"
+    haskey(h, "$det/$tier") && return "$det/$tier"
+    haskey(h, "$tier")      && return "$tier"
+    nothing
+end
+
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey, DetectorIdLike}; filterby::Base.Callable=Returns(true), n_evts::Int=-1, ignore_missing::Bool=false, subgroup::Union{Symbol,Nothing}=nothing, kwargs...)
     tier, filekey = DataTier(rsel[1]), rsel[2]
     has_det = !isempty(string(rsel[3]))
     det_arg = has_det ? DetectorId(rsel[3]) : nothing
@@ -267,12 +295,15 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
             _read_evt_perdet(h, data, filekey, tier, det_arg, f, filterby, n_evts)
         else
             has_det || throw(ArgumentError("DetectorId required for tier $tier"))
-            path = haskey(h, "$tier/$det_arg") ? "$tier/$det_arg" : "$tier"
-            if !haskey(h, path)
+            path = _resolve_perdet_path(h, tier, det_arg)
+            if path === nothing
                 ignore_missing && (@warn "Detector $det_arg not found in $(basename(string(h.data_store)))"; return nothing)
                 throw(ArgumentError("Detector $det_arg not found in $(basename(string(h.data_store)))"))
             end
-            _apply_read(h[path], f, filterby, n_evts)
+            # Optional sub-group descent (e.g. jlhit/<det>/dataQC).
+            full = subgroup === nothing ? path : "$path/$subgroup"
+            haskey(h, full) || throw(ArgumentError("Subgroup $subgroup not found at $path in $(basename(string(h.data_store)))"))
+            _apply_read(h[full], f, filterby, n_evts)
         end
     end
 end
@@ -280,8 +311,14 @@ end
 function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey}; kwargs...)
     tier = DataTier(rsel[1])
     tier in _evt_tiers && return LegendDataManagement.read_ldata(f, data, (tier, rsel[2], ""); kwargs...)
+    # Discover detectors: primary "tier/<det>" listing, fallback to legacy
+    # "<det>/tier" layout (top-level keys with a $tier subkey).
     dets = _lh5_data_open(data, tier, rsel[2]) do h
-        haskey(h, "$tier") ? collect(keys(h["$tier"])) : String[]
+        if haskey(h, "$tier")
+            collect(keys(h["$tier"]))
+        else
+            [k for k in keys(h) if haskey(h, "$k/$tier")]
+        end
     end
     isempty(dets) && throw(ArgumentError("No detectors found under /$tier in $(basename(data.tier[tier, rsel[2]]))"))
     NamedTuple{Tuple(Symbol.(dets))}([LegendDataManagement.read_ldata(f, data, (tier, rsel[2], d); kwargs...) for d in dets])

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -198,11 +198,7 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
         haskey(h, "$tier") ? collect(keys(h["$tier"])) : String[]
     end
     isempty(dets) && throw(ArgumentError("No detectors found under /$tier in $(basename(data.tier[tier, rsel[2]]))"))
-    if length(dets) == 1
-        LegendDataManagement.read_ldata(f, data, (tier, rsel[2], only(dets)); kwargs...)
-    else
-        NamedTuple{Tuple(Symbol.(dets))}([LegendDataManagement.read_ldata(f, data, (tier, rsel[2], d); kwargs...) for d in dets])
-    end
+    NamedTuple{Tuple(Symbol.(dets))}([LegendDataManagement.read_ldata(f, data, (tier, rsel[2], d); kwargs...) for d in dets])
 end
 
 function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, AbstractVector{FileKey}, DetectorIdLike}; parallel::Bool=false, wpool::WorkerPool=default_worker_pool(), kwargs...)

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -119,8 +119,22 @@ function __init__()
     (@isdefined DataPartition) && extend_datatype_dict(DataPartition, "datapartition")
 end
 
-const _evt_tiers = DataTier.([:jlevt, :jlskm])
+const _evt_tiers = DataTier.([:jlevt, :jlskm, :jlpmt])
 const _perdet_tiers = DataTier.([:jlpeaks, :jlhit, :jlpls])
+
+# For an event-tier, return the inner LH5 path that contains per-detector
+# columns (with a `detector` VoV) for the detector's system. `nothing` means
+# this (tier, system) combination has no per-detector slicing — the caller
+# must fall back to event-level reads.
+function _evt_persubdet_path(tier::DataTier, sys::Symbol)
+    if tier == DataTier(:jlevt) || tier == DataTier(:jlskm)
+        sys == :geds && return "$tier/geds"
+        sys == :spms && return "$tier/spms"
+    elseif tier == DataTier(:jlpmt)
+        sys == :pmts && return "$tier"
+    end
+    return nothing
+end
 
 # Open the LH5 file for a given tier/filekey (+det for per-detector tiers).
 function _lh5_data_open(f::Function, data::LegendData, tier::DataTierLike, filekey::FileKey, det::Union{DetectorIdLike, Nothing}=nothing, mode::AbstractString="r")
@@ -147,7 +161,10 @@ _load_all_keys(arr::AbstractArray, n_evts::Int=-1) = arr[:][if (n_evts < 1 || n_
 _load_all_keys(t::Table, n_evts::Int=-1) = t[:][if (n_evts < 1 || n_evts > length(t)) 1:length(t) else rand(1:length(t), n_evts) end]
 _load_all_keys(x, n_evts::Int=-1) = x
 
-# Apply PropSelFunction / filter / function to a loaded HDF5 node, return a Table or array
+# Apply PropSelFunction / filter / function to a loaded HDF5 node, return a
+# Table or array. The filter is missing-tolerant: rows where the filter
+# returns `missing` are dropped (same semantics as `false`), so callers can
+# write predicates over `Union{T,Missing}` columns without a manual coalesce.
 function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::Int)
     if f isa PropSelFunction && filterby == Returns(true)
         src_cols = _propfunc_src_columnnames(f)
@@ -159,120 +176,145 @@ function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::
         end)
     else
         lh5_data = _load_all_keys(h_node, n_evts)
-        filterby != Returns(true) && (lh5_data = lh5_data |> PropertyFunctions.filterby(filterby))
+        if filterby != Returns(true)
+            lh5_data = lh5_data[coalesce.(filterby.(lh5_data), false)]
+        end
         f != identity && (lh5_data = f.(lh5_data))
         TypedTables.Tables.istable(lh5_data) ? Table(lh5_data) : lh5_data
     end
 end
 
-# Per-detector read from an event-tier file. Routes by det system: geds via
-# `trig_e_det`, spms via `detector`. For each event, picks the index where
-# `det` appears, masks events without it, unwraps VoV columns at that index.
-# Event-scalar sibling subgroups (ged_spm, ft_spm, ged_pmt) and aux/<sub>/<col>
-# (flattened as `<sub>_<col>`) are exposed as flat scalar columns so a single
-# `filterby` can combine per-det and event-global flags. Fast path: when called
-# with a PropSelFunction and a PropertyFunction filterby, only the columns
-# referenced by their src tuples are materialized.
-# jlevt/geds uses two VoV indexing schemes per event:
-#   - per-trigger    (length == #triggers, e.g. trig_e_*)            → use trig_idxs
-#   - per-det-list   (length == #all_dets_in_array, e.g. e_cusp_*)   → use det_idxs
-# Decision is per-row by inner-vector length so SPMs (only per-trigger) and
-# GEDs (mixed) both work without a hardcoded column list.
-_unwrap_perdet(col::AbstractVector, _, _, _) = col
-function _unwrap_perdet(col::AbstractVector{<:AbstractVector}, trig_idxs::Vector{Int}, det_idxs::Vector{Int}, n_trig::Vector{Int})
-    [length(col[k]) == n_trig[k] ? col[k][trig_idxs[k]] : col[k][det_idxs[k]] for k in eachindex(col)]
+# Walk an event-tier HDF5 group and build a flat name-map
+# `prefix_name => (h5_path, leaf_col_symbol)`. Top-level scalar/VoV columns
+# get the bare leaf name; sub-table columns get `<sub>_<col>`; nested
+# sub-tables (e.g. `/jlevt/aux/pulser/aux_trig`) get `<sub_a>_<sub_b>_<col>`.
+# Identifies VoV groups via the `cumulative_length` / `encoded_data` markers.
+function _build_evt_namemap(h::LegendHDF5IO.LHDataStore, tier::DataTier)
+    nmap = Dict{Symbol, Tuple{String, Symbol}}()
+    h5_grp = h.data_store["$tier"]
+    try
+        _walk_evt_h5!(nmap, h5_grp, "$tier", "")
+    finally
+        close(h5_grp)
+    end
+    nmap
 end
 
-const _evt_scalar_subgroups = ("ged_spm", "ft_spm", "ged_pmt")
-
-# Load one named column from the right subgroup. Per-det subgroup cols are
-# VoV-unwrapped using trig_idxs OR det_idxs (chosen per-row by length, see
-# `_unwrap_perdet`); event-scalar and aux cols are masked only.
-function _load_perdet_col(h, tier::DataTier, persubdet, col::Symbol, mask::AbstractVector{Bool}, trig_idxs::Vector{Int}, det_idxs::Vector{Int}, n_trig::Vector{Int})
-    if col in propertynames(persubdet)
-        return _unwrap_perdet(getproperty(persubdet, col)[mask], trig_idxs, det_idxs, n_trig)
-    end
-    for g in _evt_scalar_subgroups
-        haskey(h, "$tier/$g") || continue
-        sub = h["$tier/$g"]
-        col in propertynames(sub) && return getproperty(sub, col)[:][mask]
-    end
-    if haskey(h, "$tier/aux")
-        aux_grp = h["$tier/aux"]
-        col_str = string(col)
-        for sub in propertynames(aux_grp)
-            pref = string(sub, "_")
-            if startswith(col_str, pref)
-                rest = Symbol(col_str[length(pref)+1:end])
-                subtbl = getproperty(aux_grp, sub)
-                rest in propertynames(subtbl) && return getproperty(subtbl, rest)[:][mask]
+function _walk_evt_h5!(out::Dict, group, base_path::String, prefix::String)
+    for k in keys(group)
+        full_name = isempty(prefix) ? Symbol(k) : Symbol(prefix, "_", k)
+        child = group[k]
+        try
+            if child isa LegendHDF5IO.HDF5.Dataset
+                out[full_name] = (base_path, Symbol(k))
+            elseif child isa LegendHDF5IO.HDF5.Group
+                ck = keys(child)
+                if "cumulative_length" in ck || "encoded_data" in ck
+                    out[full_name] = (base_path, Symbol(k))
+                else
+                    new_prefix = isempty(prefix) ? string(k) : "$(prefix)_$(k)"
+                    _walk_evt_h5!(out, child, "$base_path/$k", new_prefix)
+                end
             end
+        finally
+            close(child)
         end
     end
-    error("column $col not found in $tier subgroups")
 end
 
-function _read_evt_perdet(h, data::LegendData, filekey::FileKey, tier::DataTier, det::DetectorId, f::Base.Callable, filterby::Base.Callable, n_evts::Int)
-    system = channelinfo(data, filekey, det).system
-    subgrp, mask_col = if system == :geds
-        "geds", :trig_e_det
-    elseif system == :spms
-        "spms", :detector
+# Index a materialized column by per-event indices. Scalar columns and VoVs
+# whose inner length matches neither the per-det-list nor the per-trigger
+# reference (e.g. unrelated nested shapes) are returned as-is.
+function _index_col(col, det_idxs, trig_idxs, det_inner_lens, trig_inner_lens)
+    eltype(col) <: AbstractVector || return col
+    inner_lens = length.(col)
+    if det_inner_lens !== nothing && inner_lens == det_inner_lens
+        return [col[k][det_idxs[k]] for k in eachindex(col)]
+    elseif trig_inner_lens !== nothing && inner_lens == trig_inner_lens
+        return [col[k][trig_idxs[k]] for k in eachindex(col)]
     else
-        error("read_ldata(:$tier, ..., $det): no per-det data in $tier for system :$system")
+        return col
     end
-    persubdet = h["$tier/$subgrp"]
-    trig_list = getproperty(persubdet, mask_col)[:]
-    keep = [findfirst(isequal(det), t) for t in trig_list]
-    mask = .!isnothing.(keep)
-    trig_idxs = Int.(keep[mask])
-    n_trig    = length.(trig_list[mask])
-    # det-list position (e.g. for /jlevt/geds/e_cusp_ctc_cal which is indexed
-    # by the all-dets-in-array list, not by trigger position). Falls back to
-    # trig_idxs for systems / files without trig_e_det_idxs (SPMs etc.).
-    det_idxs = if hasproperty(persubdet, :trig_e_det_idxs)
-        di = getproperty(persubdet, :trig_e_det_idxs)[mask]
-        [Int(di[k][trig_idxs[k]]) for k in eachindex(trig_idxs)]
-    else
-        trig_idxs
+end
+
+# Read an event-tier table. With `det = nothing`, every column is materialized
+# in its native shape (event-scalar or VoV) under the prefix-flattened name.
+# With `det` given, only events where the detector is present are kept:
+# the mask comes from `trig_e_det` when available (for systems with a
+# per-trigger view, e.g. GEDs in jlevt) or `detector` otherwise (SPMs in
+# jlevt, PMTs in jlpmt). For surviving events, per-det-list and per-trigger
+# VoV columns are unwrapped at the detector's respective index. Other
+# subgroup columns (`ged_spm_*`, `aux_pulser_*`, …) remain event-scalar and
+# are masked alongside.
+function _read_evt_table(h::LegendHDF5IO.LHDataStore, data::LegendData, filekey::FileKey,
+        tier::DataTier, det::Union{DetectorId,Nothing}, f::Base.Callable,
+        filterby::Base.Callable, n_evts::Int)
+
+    nmap = _build_evt_namemap(h, tier)
+
+    persubdet_path = nothing
+    mask = nothing
+    det_idxs = trig_idxs = nothing
+    det_inner_lens = trig_inner_lens = nothing
+    if det !== nothing
+        sys = channelinfo(data, filekey, det).system
+        persubdet_path = _evt_persubdet_path(tier, sys)
+        persubdet_path === nothing &&
+            error("read_ldata(:$tier, ..., $det): no per-det data in $tier for system :$sys")
+        haskey(h, persubdet_path) ||
+            error("read_ldata(:$tier, ..., $det): /$persubdet_path missing in file")
+        psd = h[persubdet_path]
+
+        # Find the detector's per-event position in `trig_e_det` (preferred,
+        # exists for GED-like systems) or `detector` (fallback for SPMs/PMTs).
+        # The chosen list also drives the event mask: events where the
+        # detector did not trigger / is not in the array are dropped.
+        if hasproperty(psd, :trig_e_det)
+            tl = getproperty(psd, :trig_e_det)[:]
+            keep = [findfirst(isequal(det), t) for t in tl]
+            mask = .!isnothing.(keep)
+            trig_idxs = Int.(keep[mask])
+            trig_inner_lens = length.(tl[mask])
+        end
+        if hasproperty(psd, :detector)
+            dl = getproperty(psd, :detector)[:]
+            keep = [findfirst(isequal(det), t) for t in dl]
+            mask === nothing && (mask = .!isnothing.(keep))
+            det_idxs = Int.(keep[mask])
+            det_inner_lens = length.(dl[mask])
+        end
+        mask === nothing &&
+            error("read_ldata(:$tier, ..., $det): /$persubdet_path has neither :detector nor :trig_e_det")
     end
 
-    # Fast path: lazy load only the columns needed by PropSel + filterby
+    function load_col(name::Symbol)
+        haskey(nmap, name) ||
+            error("column $name not found in /$tier (available: $(sort(collect(keys(nmap)))))")
+        (path, col) = nmap[name]
+        raw = getproperty(h[path], col)[:]
+        mask === nothing && return raw
+        masked = raw[mask]
+        path == persubdet_path ? _index_col(masked, det_idxs, trig_idxs, det_inner_lens, trig_inner_lens) : masked
+    end
+
+    # Fast path: only materialize columns referenced by PropSel + filterby.
     if f isa PropSelFunction && (filterby isa PropertyFunctions.PropertyFunction || filterby === Returns(true))
         src_cols = _propfunc_src_columnnames(f)
         trg_cols = _propfunc_trg_columnnames(f)
         filt_cols = _propfunc_src_columnnames(filterby)
         needed = Tuple(unique((src_cols..., filt_cols...)))
-        cols = map(c -> _load_perdet_col(h, tier, persubdet, c, mask, trig_idxs, det_idxs, n_trig), needed)
+        cols = map(load_col, needed)
         tbl = Table(NamedTuple{needed}(cols))
-        filt_tbl = filterby === Returns(true) ? tbl : (tbl |> PropertyFunctions.filterby(filterby))
+        filt_tbl = filterby === Returns(true) ? tbl : tbl[coalesce.(filterby.(tbl), false)]
         n_evts > 0 && (filt_tbl = filt_tbl[1:min(n_evts, length(filt_tbl))])
         out_cols = Tuple(getproperty(filt_tbl, c) for c in src_cols)
         return Table(NamedTuple{trg_cols}(out_cols))
     end
 
-    # Eager fallback: build full merged table
-    col_names = propertynames(persubdet)
-    cols = map(c -> _unwrap_perdet(getproperty(persubdet, c)[mask], trig_idxs, det_idxs, n_trig), col_names)
-    nt = NamedTuple{col_names}(cols)
-    for g in _evt_scalar_subgroups
-        haskey(h, "$tier/$g") || continue
-        sub = h["$tier/$g"]
-        sub_names = propertynames(sub)
-        sub_cols = map(c -> getproperty(sub, c)[:][mask], sub_names)
-        nt = merge(nt, NamedTuple{sub_names}(sub_cols))
-    end
-    if haskey(h, "$tier/aux")
-        aux_grp = h["$tier/aux"]
-        for sub in propertynames(aux_grp)
-            subtbl = getproperty(aux_grp, sub)
-            sub_names = propertynames(subtbl)
-            prefixed = Tuple(Symbol(sub, :_, n) for n in sub_names)
-            sub_cols = map(c -> getproperty(subtbl, c)[:][mask], sub_names)
-            nt = merge(nt, NamedTuple{prefixed}(sub_cols))
-        end
-    end
-    _apply_read(Table(nt), f, filterby, n_evts)
+    # Eager fallback: load every column, then apply f / filterby / n_evts.
+    all_names = Tuple(sort(collect(keys(nmap))))
+    cols = map(load_col, all_names)
+    _apply_read(Table(NamedTuple{all_names}(cols)), f, filterby, n_evts)
 end
 
 # Resolve the inner HDF5 path for (tier, det). Primary: "tier/det". Legacy
@@ -291,8 +333,7 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
 
     _lh5_data_open(data, tier, filekey, det_arg) do h
         if tier in _evt_tiers
-            has_det || return _apply_read(h["$tier"], f, filterby, n_evts)
-            _read_evt_perdet(h, data, filekey, tier, det_arg, f, filterby, n_evts)
+            _read_evt_table(h, data, filekey, tier, det_arg, f, filterby, n_evts)
         else
             has_det || throw(ArgumentError("DetectorId required for tier $tier"))
             path = _resolve_perdet_path(h, tier, det_arg)

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -123,9 +123,14 @@ const _evt_tiers = DataTier.([:jlevt, :jlskm])
 const _perdet_tiers = DataTier.([:jlpeaks, :jlhit, :jlpls])
 
 # Open the LH5 file for a given tier/filekey (+det for per-detector tiers).
-function _lh5_data_open(f::Function, data::LegendData, tier::DataTierLike, filekey::FileKey, det::DetectorIdLike=DetectorId(""), mode::AbstractString="r")
+function _lh5_data_open(f::Function, data::LegendData, tier::DataTierLike, filekey::FileKey, det::Union{DetectorIdLike, Nothing}=nothing, mode::AbstractString="r")
     t = DataTier(tier)
-    path = t in _perdet_tiers ? data.tier[t, filekey, DetectorId(det)] : data.tier[t, filekey]
+    if t in _perdet_tiers
+        isnothing(det) && throw(ArgumentError("DetectorId required for per-detector tier $t"))
+        path = data.tier[t, filekey, DetectorId(det)]
+    else
+        path = data.tier[t, filekey]
+    end
     LegendHDF5IO.lh5open(f, path, mode)
 end
 
@@ -133,8 +138,9 @@ _skipnothingmissing(xv::AbstractVector) = [x for x in skipmissing(xv) if !isnoth
 lflatten(x) = fast_flatten(collect(_skipnothingmissing(x)))
 lflatten(nt::AbstractVector{<:NamedTuple}) = flatten_by_key(collect(_skipnothingmissing(nt)))
 
-_propfunc_src_columnnames(f::PropSelFunction{src_cols, trg_cols}) where {src_cols, trg_cols} = src_cols
-_propfunc_trg_columnnames(f::PropSelFunction{src_cols, trg_cols}) where {src_cols, trg_cols} = trg_cols
+_propfunc_src_columnnames(::PropertyFunctions.PropertyFunction{names}) where names = names
+_propfunc_src_columnnames(::Any) = ()
+_propfunc_trg_columnnames(::PropSelFunction{src, trg}) where {src, trg} = trg
 
 _load_all_keys(nt::NamedTuple, n_evts::Int=-1) = if length(nt) == 1 _load_all_keys(nt[first(keys(nt))], n_evts) else NamedTuple{keys(nt)}(map(x -> _load_all_keys(nt[x], n_evts), keys(nt))) end
 _load_all_keys(arr::AbstractArray, n_evts::Int=-1) = arr[:][if (n_evts < 1 || n_evts > length(arr)) 1:length(arr) else rand(1:length(arr), n_evts) end]
@@ -159,23 +165,106 @@ function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::
     end
 end
 
-# Per-detector read from an event-tier file: filter events where `det` triggered and
-# apply `f` (PropSelFunction targets columns in jlevt/geds by default).
-function _read_evt_perdet(h, tier::DataTier, det::DetectorId, f::Base.Callable, filterby::Base.Callable, n_evts::Int)
-    mask = any.(isequal(det), h["$tier/geds/trig_e_det"][:])
-    geds = _apply_read(h["$tier/geds"], f, filterby, -1)
-    geds[mask]
+# Per-detector read from an event-tier file. Routes by det system: geds via
+# `trig_e_det`, spms via `detector`. For each event, picks the index where
+# `det` appears, masks events without it, unwraps VoV columns at that index.
+# Event-scalar sibling subgroups (ged_spm, ft_spm, ged_pmt) and aux/<sub>/<col>
+# (flattened as `<sub>_<col>`) are exposed as flat scalar columns so a single
+# `filterby` can combine per-det and event-global flags. Fast path: when called
+# with a PropSelFunction and a PropertyFunction filterby, only the columns
+# referenced by their src tuples are materialized.
+_unwrap_perdet(col::AbstractVector{<:AbstractVector}, idxs::Vector{Int}) = getindex.(col, idxs)
+_unwrap_perdet(col::AbstractVector, ::Vector{Int}) = col
+
+const _evt_scalar_subgroups = ("ged_spm", "ft_spm", "ged_pmt")
+
+# Load one named column from the right subgroup. Per-det subgroup cols are
+# VoV-unwrapped at `idxs`; event-scalar and aux cols are masked only.
+function _load_perdet_col(h, tier::DataTier, persubdet, col::Symbol, mask::AbstractVector{Bool}, idxs::Vector{Int})
+    if col in propertynames(persubdet)
+        return _unwrap_perdet(getproperty(persubdet, col)[mask], idxs)
+    end
+    for g in _evt_scalar_subgroups
+        haskey(h, "$tier/$g") || continue
+        sub = h["$tier/$g"]
+        col in propertynames(sub) && return getproperty(sub, col)[:][mask]
+    end
+    if haskey(h, "$tier/aux")
+        aux_grp = h["$tier/aux"]
+        col_str = string(col)
+        for sub in propertynames(aux_grp)
+            pref = string(sub, "_")
+            if startswith(col_str, pref)
+                rest = Symbol(col_str[length(pref)+1:end])
+                subtbl = getproperty(aux_grp, sub)
+                rest in propertynames(subtbl) && return getproperty(subtbl, rest)[:][mask]
+            end
+        end
+    end
+    error("column $col not found in $tier subgroups")
+end
+
+function _read_evt_perdet(h, data::LegendData, filekey::FileKey, tier::DataTier, det::DetectorId, f::Base.Callable, filterby::Base.Callable, n_evts::Int)
+    system = channelinfo(data, filekey, det).system
+    subgrp, mask_col = if system == :geds
+        "geds", :trig_e_det
+    elseif system == :spms
+        "spms", :detector
+    else
+        error("read_ldata(:$tier, ..., $det): no per-det data in $tier for system :$system")
+    end
+    persubdet = h["$tier/$subgrp"]
+    keep = [findfirst(isequal(det), t) for t in getproperty(persubdet, mask_col)[:]]
+    mask = .!isnothing.(keep)
+    idxs = Int.(keep[mask])
+
+    # Fast path: lazy load only the columns needed by PropSel + filterby
+    if f isa PropSelFunction && (filterby isa PropertyFunctions.PropertyFunction || filterby === Returns(true))
+        src_cols = _propfunc_src_columnnames(f)
+        trg_cols = _propfunc_trg_columnnames(f)
+        filt_cols = _propfunc_src_columnnames(filterby)
+        needed = Tuple(unique((src_cols..., filt_cols...)))
+        cols = map(c -> _load_perdet_col(h, tier, persubdet, c, mask, idxs), needed)
+        tbl = Table(NamedTuple{needed}(cols))
+        filt_tbl = filterby === Returns(true) ? tbl : (tbl |> PropertyFunctions.filterby(filterby))
+        n_evts > 0 && (filt_tbl = filt_tbl[1:min(n_evts, length(filt_tbl))])
+        out_cols = Tuple(getproperty(filt_tbl, c) for c in src_cols)
+        return Table(NamedTuple{trg_cols}(out_cols))
+    end
+
+    # Eager fallback: build full merged table
+    col_names = propertynames(persubdet)
+    cols = map(c -> _unwrap_perdet(getproperty(persubdet, c)[mask], idxs), col_names)
+    nt = NamedTuple{col_names}(cols)
+    for g in _evt_scalar_subgroups
+        haskey(h, "$tier/$g") || continue
+        sub = h["$tier/$g"]
+        sub_names = propertynames(sub)
+        sub_cols = map(c -> getproperty(sub, c)[:][mask], sub_names)
+        nt = merge(nt, NamedTuple{sub_names}(sub_cols))
+    end
+    if haskey(h, "$tier/aux")
+        aux_grp = h["$tier/aux"]
+        for sub in propertynames(aux_grp)
+            subtbl = getproperty(aux_grp, sub)
+            sub_names = propertynames(subtbl)
+            prefixed = Tuple(Symbol(sub, :_, n) for n in sub_names)
+            sub_cols = map(c -> getproperty(subtbl, c)[:][mask], sub_names)
+            nt = merge(nt, NamedTuple{prefixed}(sub_cols))
+        end
+    end
+    _apply_read(Table(nt), f, filterby, n_evts)
 end
 
 function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey, DetectorIdLike}; filterby::Base.Callable=Returns(true), n_evts::Int=-1, ignore_missing::Bool=false, kwargs...)
     tier, filekey = DataTier(rsel[1]), rsel[2]
     has_det = !isempty(string(rsel[3]))
-    det_arg = has_det ? DetectorId(rsel[3]) : DetectorId("")
+    det_arg = has_det ? DetectorId(rsel[3]) : nothing
 
     _lh5_data_open(data, tier, filekey, det_arg) do h
         if tier in _evt_tiers
             has_det || return _apply_read(h["$tier"], f, filterby, n_evts)
-            _read_evt_perdet(h, tier, det_arg, f, filterby, n_evts)
+            _read_evt_perdet(h, data, filekey, tier, det_arg, f, filterby, n_evts)
         else
             has_det || throw(ArgumentError("DetectorId required for tier $tier"))
             path = haskey(h, "$tier/$det_arg") ? "$tier/$det_arg" : "$tier"
@@ -219,6 +308,9 @@ LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{
 ### Argument distinction for different DataSelector Types
 function _convert_rsel2dsel(rsel::NTuple{<:Any, AbstractDataSelectorLike})
     selector_types = [PossibleDataSelectors[LegendDataManagement._can_convert_to.(PossibleDataSelectors, Ref(s))] for s in rsel]
+    if length(selector_types[1]) > 1 && DataTier in selector_types[1]
+        selector_types[1] = [DataTier]
+    end
     if length(selector_types[2]) > 1 && DataCategory in selector_types[2]
         selector_types[2] = [DataCategory]
     end


### PR DESCRIPTION
In [calibrate_all l48](https://github.com/legend-exp/LegendEventAnalysis.jl/blob/main/src/calibrate_all.jl)  we defined `trig_e_det` instead of the old `trig_e_ch` version, which was not yet fixed in the `read_ldata` access via `read_ldata(l200, :jlevt, fk_evt, det))`. I think we then also have to reprocess the PRL data set at some point. I dont want to allow both options for `trig_e_det` and `trig_e_ch`. But read_ldata works for the latest version of `LegendEventAnalysis` with `det` and `ch` argument. 