### PR TITLE
change key filter of raw files to only allow DetectorID's

### DIFF
--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -15,7 +15,7 @@ const AbstractDataSelectorLike = Union{AbstractString, Symbol, DataTierLike, Dat
 const PossibleDataSelectors = [DataTier, DataCategory, DataPeriod, DataRun, DataPartition, ChannelId, DetectorId]
 
 function _is_valid_id_or_tier(data::LegendData, rsel::Union{AnyValiditySelection, RunCategorySelLike}, id::ChannelOrDetectorIdLike)
-    if LegendDataManagement._can_convert_to(ChannelId, id) ||  LegendDataManagement._can_convert_to(DetectorId, id) ||  LegendDataManagement._can_convert_to(DataTier, id)
+    if LegendDataManagement._can_convert_to(DetectorId, id)
         true  
     else  
         @warn "Skipped $id since it is neither a valid `ChannelId`, `DetectorId` nor a `DataTier`"  


### PR DESCRIPTION
Hi this PR fixes https://github.com/legend-exp/LegendDataManagement.jl/issues/135. 
I described the Problem in greater detail in that issue. 

This fix changes the filtering of keys for the raw tier to only allow DetectorID's.

I would also change the warning line, as it currently is very noisy when opening raw files. Should i instead replace it with an `@debug` or remove the entire line?