### PR TITLE
Refactor read_ldata() and update docs 

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -62,58 +62,85 @@ The following additional keywords arguments can be set (the `plot_waveform` kwar
 
 ## `LegendHDF5IO` extension
 
-LegendDataManagment provides an extension for [LegendHDF5IO](https://github.com/legend-exp/LegendHDF5IO.jl).
-This makes it possible to directly load LEGEND data from HDF5 files via the `read_ldata` function. The extension is automatically loaded when both packages are loaded. 
-Example (requires a `$LEGEND_DATA_CONFIG` environment variable pointing to a legend data-config file):
-    
+LegendDataManagement provides an extension for [LegendHDF5IO](https://github.com/legend-exp/LegendHDF5IO.jl) that exposes `read_ldata` for loading LEGEND data from HDF5 files. The extension auto-loads when both packages are loaded. All examples assume `$LEGEND_DATA_CONFIG` is set.
+
 ```julia
-using LegendDataManagement, LegendHDF5IO
+using LegendDataManagement, LegendHDF5IO, PropertyFunctions
+using Unitful: @u_str
+
 l200 = LegendData(:l200)
-filekeys = search_disk(FileKey, l200.tier[:jldsp, :cal, :p03, :r000])
-
-chinfo = channelinfo(l200, (:p03, :r000, :cal); system=:geds, only_processable=true)
-
-ch = chinfo[1].channel
-
-dsp = read_ldata(l200, :jldsp, first(filekeys), ch)
-dsp = read_ldata(l200, :jldsp, :cal, :p03, :r000, ch)
-dsp = read_ldata((:e_cusp, :e_trap, :blmean, :blslope), l200, :jldsp, :cal, :p03, :r000, ch)
+fk   = first(search_disk(FileKey, l200.tier[:jldsp, :cal, :p03, :r000]))
+det  = first(filter(c -> c.system == :geds && c.processable, channelinfo(l200, fk))).detector
 ```
-`read_ldata` automitcally loads LEGEND data for a specific `DataTier` and data selection like e.g. a `FileKey` or a run-selection based for a given `ChannelId`. The `search_disk` function allows the user to search for available `DataTier` and `FileKey` on disk. The first argument can be either a selection of keys in form of a `NTuple` of `Symbol` or a [PropertyFunction](https://github.com/oschulz/PropertyFunctions.jl/tree/main) which will be applied during loading. 
-It is also possible to load whole a `DataPartition` or `DataPeriod` for a given `ChannelId` ch:
+
+### Selecting columns
+
+Three equivalent forms (all return a `Table`):
+
 ```julia
-dsp = read_ldata(l200, :jldsp, :cal, DataPartition(1), ch)
-dsp = read_ldata(l200, :jldsp, :cal, DataPeriod(3), ch)
+read_ldata(l200, :jldsp, fk, det)                                       # all columns
+read_ldata((:e_cusp, :timestamp), l200, (:jldsp, fk, det))              # tuple of names
+read_ldata(@pf((; $e_cusp, $timestamp)), l200, (:jldsp, fk, det))       # PropSel via @pf
 ```
-In additon, it is possible to load a random selection of `n_evts` events randomly selected from each loaded file:
-```julia
-dsp = read_ldata(l200, :jldsp, :cal, :p03, :r000, ch; n_evts=1000)
-```
-For simplicity, the ch can also be given as a `DetectorID` which will be converted internally to a `ChannelId`:
-```julia
-det = chinfo[1].detector
-dsp = read_ldata(l200, :jldsp, :cal, :p03, :r000, det)
-```
-In case, a `ChannelId` is missing in a file, the function will throw an `ArgumentError`. To avoid this and return `nothing` instead, you can use the `ignore_missing` keyword argument.
 
-The data can be filtered by a `filterby` keyword argument which is a [PropertyFunction](https://github.com/oschulz/PropertyFunctions.jl/tree/main) applied to each chunk of loaded data:
-```julia
-dsp = read_ldata(l200, :jldsp, :cal, :p03, :r000, ch; filterby=@pf($e_trap > 0.0))
-```
-This will only load data where the `e_trap` property is greater than 0.
+The PropSel form enables a fast path that only loads the requested leaf columns from disk.
 
-It is possible to read in multiple files in parallel using the `Distributed` functionalities from within a session. You can activate parallel read with the `parallel` kwarg.
-``` julia
-dsp = read_ldata(l200, :jldsp, :cal, DataPeriod(3), ch)
-dsp = read_ldata(l200, :jldsp, :cal, DataPeriod(3), ch; parallel=true)
+### Per-detector slicing across tiers
+
+`read_ldata(_, l200, (tier, fk, det))` works for raw, jldsp, jlhit, jlpls, jlpeaks, and the event tiers jlevt, jlskm, jlpmt. The detector can be a GED, SiPM, or PMT — the system is picked up from `channelinfo`. Without a detector, an event-tier read returns the native nested LH5 layout:
+
+```julia
+read_ldata(l200, :raw,   fk, det)        # raw waveforms for one detector
+read_ldata(l200, :jlpmt, fk, pmt_det)    # PMT event-tier table
+evt = read_ldata(l200, :jlevt, fk)       # nested: evt.aux.pulser.aux_trig, evt.geds.is_valid_qc, …
 ```
-However, it is necessary that a worker allocation was already performed and the `LegendDataManagement` as well as `LegendHDF5IO` package is loaded on all workers, e.g. with
-``` julia
-using Distributed
-addprocs(4)
-@everywhere using LegendDataManagement, LegendHDF5IO
+
+For the per-det event-tier read the columns are flat-prefixed (`geds_e_cusp_ctc_cal`, `geds_trig_e_cusp_ctc_cal`, `spms_trig_max_cal`, `aux_pulser_aux_trig`, `ged_spm_is_valid_lar`, …). Per-trigger and per-det-list VoVs are unwrapped at the detector's per-event slot, and only events where the detector triggered are kept.
+
+### Filtering during the read
+
+`filterby` is a `PropertyFunction` applied row-wise to the loaded table; `missing` predicate values are dropped (treated as `false`):
+
+```julia
+read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, fk, det);
+           filterby = @pf $geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV")
 ```
-In addition, the `wpool`kwarg allows to parse a custome `WorkerPool` for more sophisticated load patterns.
+
+### Cross-tier filter
+
+The `filtertier` kwarg lets a per-detector read use a filter from a different tier. Two modes, both keyed by detector:
+
+- **event tier → raw / jldsp** — uses the per-det `*_dataidx` column to slice (1-based, same for raw and jldsp). Use this to pull, e.g., raw waveforms only for events that pass an event-level QC cut.
+- **raw ↔ jldsp** — uses the 1:1 row alignment between raw and jldsp for a given detector and applies a Bool row-mask. Works for `phy` *and* `cal` (no event tier needed).
+
+```julia
+# Raw waveforms of phy events that pass an event-tier QC + energy cut
+read_ldata(@pf((; $waveform_presummed, $timestamp)),
+           l200, (:raw, fk, det);
+           filterby   = @pf $geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV",
+           filtertier = :jlevt)
+
+# Cal raw waveforms for events with high reconstructed dsp energy (no jlevt for cal)
+read_ldata((:waveform_presummed,), l200, (:raw, fk_cal, det);
+           filterby   = @pf $e_cusp > 1000,
+           filtertier = :jldsp)
+```
+
+### Run / period / partition selection
+
+```julia
+read_ldata(l200, :jldsp, :cal, :p03, :r000, det)            # one run
+read_ldata(l200, :jldsp, :cal, DataPeriod(3),    det)       # one period
+read_ldata(l200, :jldsp, :cal, DataPartition(1), det)       # one partition
+```
+
+A `Vector{FileKey}` is also accepted as the second selector. Both `parallel=true` and a `wpool::WorkerPool` are supported for `Distributed` reads (workers must have `LegendDataManagement` and `LegendHDF5IO` loaded).
+
+### Other kwargs
+
+- `subgroup=:dataQC` — descend into a per-det sub-group (e.g. `jlhit/<det>/dataQC`).
+- `n_evts=1000` — random sample of `n_evts` rows per file.
+- `ignore_missing=true` — return `nothing` instead of throwing when a detector is missing in a file.
 
 ## `SolidStateDetectors` extension
 

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -83,63 +83,145 @@ read_ldata((:e_cusp, :timestamp), l200, (:jldsp, fk, det))              # tuple 
 read_ldata(@pf((; $e_cusp, $timestamp)), l200, (:jldsp, fk, det))       # PropSel via @pf
 ```
 
-The PropSel form enables a fast path that only loads the requested leaf columns from disk.
+The PropSel form enables a fast path that only loads the requested leaf columns from disk; the tuple form is sugar for the same. A bare `Symbol` (`read_ldata(:e_cusp, l200, …)`) is sugar for `(:e_cusp,)`.
 
 ### Per-detector slicing across tiers
 
-`read_ldata(_, l200, (tier, fk, det))` works for raw, jldsp, jlhit, jlpls, jlpeaks, and the event tiers jlevt, jlskm, jlpmt. The detector can be a GED, SiPM, or PMT — the system is picked up from `channelinfo`. Without a detector, an event-tier read returns the native nested LH5 layout:
+`read_ldata(_, l200, (tier, fk, det))` works for `:raw`, `:jldsp`, `:jlhit`, `:jlpls`, `:jlpeaks`, and the event tiers `:jlevt`, `:jlskm`, `:jlpmt`. The detector system (`:geds`, `:spms`, `:pmts`) is auto-detected from `channelinfo` — no need to pass it.
+
+| Tier              | With detector                                        | Without detector                       |
+|-------------------|------------------------------------------------------|----------------------------------------|
+| `raw`, `jldsp`    | per-detector Table                                   | NamedTuple of per-detector Tables      |
+| `jlhit`, `jlpls`  | per-detector Table (use `subgroup=` to descend)      | NamedTuple of per-detector Tables      |
+| `jlevt`, `jlskm`  | flat-prefixed Table for that detector                | nested LH5 view (multi-detector)       |
+| `jlpmt`           | per-PMT Table                                        | flat top-level Table (no `geds`/`spms`)|
+
+#### Per-detector event-tier read (flat-prefixed)
 
 ```julia
-read_ldata(l200, :raw,   fk, det)        # raw waveforms for one detector
-read_ldata(l200, :jlpmt, fk, pmt_det)    # PMT event-tier table
-evt = read_ldata(l200, :jlevt, fk)       # nested: evt.aux.pulser.aux_trig, evt.geds.is_valid_qc, …
+read_ldata((:geds_e_cusp_ctc_cal, :geds_trig_e_cusp_ctc_cal),
+           l200, (:jlevt, fk_phy, det))
 ```
 
-For the per-det event-tier read the columns are flat-prefixed (`geds_e_cusp_ctc_cal`, `geds_trig_e_cusp_ctc_cal`, `spms_trig_max_cal`, `aux_pulser_aux_trig`, `ged_spm_is_valid_lar`, …). Per-trigger and per-det-list VoVs are unwrapped at the detector's per-event slot, and only events where the detector triggered are kept.
+Columns are flat-prefixed by sub-group: `geds_e_cusp_ctc_cal`, `geds_trig_e_cusp_ctc_cal`, `spms_trig_max_cal`, `aux_pulser_aux_trig`, `ged_spm_is_valid_lar`, … The name-map is built dynamically by walking the HDF5 group, so new sub-groups need no code change. Per-trigger and per-det-list VoVs are unwrapped at the detector's per-event slot, and only events where the detector triggered are kept.
+
+#### No-detector event-tier read (nested LH5)
+
+```julia
+evt = read_ldata(l200, :jlevt, fk_phy)
+evt.aux.pulser.aux_trig          # Vector{Bool}
+evt.geds.is_valid_qc             # Vector{Bool}
+evt.geds.detector                # VoV{DetectorId} — per event, list of triggered dets
+evt.geds.e_cusp_ctc_cal          # VoV{Float} — per event, list of energies
+```
+
+The native nested layout is preserved here; this matches the layout `process_evt_phy` etc. expect.
+
+#### Sub-group descent (`subgroup=`)
+
+For tiers that nest data inside per-detector groups (e.g. `jlhit/<det>/dataQC`):
+
+```julia
+read_ldata(@pf((; $e_cusp, $timestamp)), l200, (:jlhit, fk_cal, det); subgroup=:dataQC)
+read_ldata((:is_physical,),               l200, (:jlhit, fk_cal, det); subgroup=:qc)
+read_ldata((:daqenergy, :timestamp),      l200, (:jlpls, fk_cal, "PULS01"); subgroup=:tags)
+```
+
+#### Multi-detector discovery
+
+Calling `read_ldata(l200, tier, fk)` without a detector on a per-detector tier returns a `NamedTuple` keyed by detector id:
+
+```julia
+all = read_ldata(l200, :jldsp, fk_cal)      # NamedTuple — all dets in this filekey
+all.B00000C.e_cusp                          # access by detector name
+```
 
 ### Filtering during the read
 
-`filterby` is a `PropertyFunction` applied row-wise to the loaded table; `missing` predicate values are dropped (treated as `false`):
+`filterby` is a `PropertyFunction` applied row-wise to the loaded table; `missing` predicate values are dropped (same as `false`):
 
 ```julia
-read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, fk, det);
+# Trigger-energy cut on top of the per-det mask
+read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, fk_phy, det);
            filterby = @pf $geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV")
+
+# Cross-subgroup QC: geds + ged_spm + !aux_muonveto + !aux_pulser
+read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, fk_phy, det);
+           filterby = @pf $geds_is_valid_qc && $ged_spm_is_valid_lar &&
+                          !$aux_muonveto_aux_trig && !$aux_pulser_aux_trig)
+
+# Bare-bool column: write `== true` (PropertyFunctions doesn't accept `@pf $x` alone)
+read_ldata((:e_cusp,), l200, (:jldsp, fk, det); filterby = @pf $is_valid_muon == true)
 ```
 
-### Cross-tier filter
+#### `@pf` flat names vs dot syntax
 
-The `filtertier` kwarg lets a per-detector read use a filter from a different tier. Two modes, both keyed by detector:
+- `@pf $geds_is_valid_qc` — single source column → `PropertyFunction` with one named source. The reader can match against on-disk columns and the **fast path** loads only what's needed. Use this with the per-detector flat-prefix Table.
+- `@pf $geds.is_valid_qc == true` — generic `getproperty` chain. Evaluated row-wise on the *whole* loaded object, so the fast path is bypassed. Use this on the no-detector nested LH5 view.
 
-- **event tier → raw / jldsp** — uses the per-det `*_dataidx` column to slice (1-based, same for raw and jldsp). Use this to pull, e.g., raw waveforms only for events that pass an event-level QC cut.
-- **raw ↔ jldsp** — uses the 1:1 row alignment between raw and jldsp for a given detector and applies a Bool row-mask. Works for `phy` *and* `cal` (no event tier needed).
+### Cross-tier filter (`filtertier` kwarg)
+
+A per-detector raw/jldsp read can be filtered by a predicate evaluated on a different tier. Two modes, both keyed by the same detector:
+
+- **event tier → raw / jldsp** — slices via the per-det `*_dataidx` column (1-based, same for raw and jldsp). For `geds`: `geds_dataidx`; for `spms`: `spms_dataidx`; for `pmts`: `dataidx`.
+- **raw ↔ jldsp** — uses the 1:1 row alignment between raw and jldsp for a given detector and applies a `Bool` row-mask. Works for `phy` *and* `cal` (the latter has no jlevt — so `:jldsp` is the only useful filtertier there).
 
 ```julia
 # Raw waveforms of phy events that pass an event-tier QC + energy cut
 read_ldata(@pf((; $waveform_presummed, $timestamp)),
-           l200, (:raw, fk, det);
+           l200, (:raw, fk_phy, det);
            filterby   = @pf $geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV",
            filtertier = :jlevt)
 
-# Cal raw waveforms for events with high reconstructed dsp energy (no jlevt for cal)
+# jldsp filtered by an event-tier predicate
+read_ldata((:e_cusp, :t50), l200, (:jldsp, fk_phy, det);
+           filterby   = @pf $ged_spm_is_valid_lar == true,
+           filtertier = :jlevt)
+
+# Cal raw waveforms with a dsp-energy cut (cal has no jlevt)
 read_ldata((:waveform_presummed,), l200, (:raw, fk_cal, det);
            filterby   = @pf $e_cusp > 1000,
            filtertier = :jldsp)
+
+# Symmetric direction (jldsp filtered by raw column, e.g. daqenergy)
+read_ldata((:e_cusp,), l200, (:jldsp, fk_phy, det);
+           filterby   = (@pf $daqenergy > 100),
+           filtertier = :raw)
 ```
+
+`filtertier` defaults to the current tier (no cross-tier slicing). It requires a detector and rejects non-event tiers as filtertier when the *target* is an event tier.
 
 ### Run / period / partition selection
 
 ```julia
-read_ldata(l200, :jldsp, :cal, :p03, :r000, det)            # one run
-read_ldata(l200, :jldsp, :cal, DataPeriod(3),    det)       # one period
-read_ldata(l200, :jldsp, :cal, DataPartition(1), det)       # one partition
+read_ldata(l200, :jldsp, fk, det)                            # one filekey
+read_ldata(l200, :jldsp, [fk1, fk2, fk3], det)               # multiple filekeys
+read_ldata(l200, :jldsp, :cal, :p03, :r000, det)             # one run (all filekeys)
+read_ldata(l200, :jldsp, :cal, DataPeriod(3),    det)        # one period
+read_ldata(l200, :jldsp, :cal, DataPartition(1), det)        # one partition
 ```
 
-A `Vector{FileKey}` is also accepted as the second selector. Both `parallel=true` and a `wpool::WorkerPool` are supported for `Distributed` reads (workers must have `LegendDataManagement` and `LegendHDF5IO` loaded).
+`PropSel`, `filterby` and `filtertier` work the same with all of these.
+
+#### Distributed reads
+
+Multi-filekey selectors accept `parallel=true` and a custom `wpool::WorkerPool`:
+
+```julia
+using Distributed
+addprocs(4)
+@everywhere using LegendDataManagement, LegendHDF5IO
+
+read_ldata((:e_cusp,), l200, (:jldsp, fks_phy, det);
+           filterby = @pf $e_cusp > 0, parallel=true)
+```
+
+Workers must have both packages loaded. Without `parallel=true`, a sequential progress bar is shown; with it, `progress_pmap` distributes the per-filekey reads across the worker pool.
 
 ### Other kwargs
 
 - `subgroup=:dataQC` — descend into a per-det sub-group (e.g. `jlhit/<det>/dataQC`).
-- `n_evts=1000` — random sample of `n_evts` rows per file.
+- `n_evts=1000` — random sample of `n_evts` rows per file (applied after `filterby`).
 - `ignore_missing=true` — return `nothing` instead of throwing when a detector is missing in a file.
 
 ## `SolidStateDetectors` extension

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -163,7 +163,7 @@ read_ldata((:e_cusp,), l200, (:jldsp, fk, det); filterby = @pf $is_valid_muon ==
 
 A per-detector raw/jldsp read can be filtered by a predicate evaluated on a different tier. Two modes, both keyed by the same detector:
 
-- **event tier → raw / jldsp** — slices via the per-det `*_dataidx` column (1-based, same for raw and jldsp). For `geds`: `geds_dataidx`; for `spms`: `spms_dataidx`; for `pmts`: `dataidx`.
+- **event tier → raw / jldsp** — slices via the per-det `*_detevtno` column (1-based, same for raw and jldsp). For `geds`: `geds_detevtno`; for `spms`: `spms_detevtno`; for `pmts`: `detevtno`.
 - **raw ↔ jldsp** — uses the 1:1 row alignment between raw and jldsp for a given detector and applies a `Bool` row-mask. Works for `phy` *and* `cal` (the latter has no jlevt — so `:jldsp` is the only useful filtertier there).
 
 ```julia

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -91,14 +91,15 @@ det     = first(filter(c -> c.system == :geds && c.processable, channelinfo(l200
 The third positional argument is an `rsel` tuple; you can also spread its elements positionally (`read_ldata(data, tier, args...)`). All forms accept the kwargs from the sections below. Multi-filekey, multi-run, and partition forms additionally accept `parallel=true` and `wpool::WorkerPool`.
 
 ```julia
-# By filekey
-read_ldata(l200, :jldsp, fk_cal)                              # (tier, fk)              no det → NamedTuple per det
+# By filekey (use any tier — :raw, :jldsp, :jlhit, :jlevt, …)
+read_ldata(l200, :raw,   fk_phy)                              # (tier, fk)              no det → NamedTuple per det
 read_ldata(l200, :jldsp, fk_cal, det)                         # (tier, fk, det)
-read_ldata(l200, :jldsp, fks_phy, det)                        # (tier, [fks], det)      multi-fk
+read_ldata(l200, :raw,   fks_phy, det)                        # (tier, [fks], det)      multi-fk
 
-# By period / run (det required for per-det tiers)
+# By period / run / partition
+read_ldata(l200, :jldsp, :cal, :p03, :r000)                   # (tier, cat, period, run)        no det
+read_ldata(l200, :raw,   :phy, :p03, :r000, det)              # (tier, cat, period, run, det)
 read_ldata(l200, :jldsp, :cal, :p03, det)                     # (tier, cat, period, det)
-read_ldata(l200, :jldsp, :cal, :p03, :r000, det)              # (tier, cat, period, run, det)
 read_ldata(l200, :jldsp, :cal, DataPartition(1), det)         # (tier, cat, partition, det)
 
 # Custom run set (Table with :period and :run columns)
@@ -107,6 +108,8 @@ read_ldata(l200, :jldsp, :cal, runs, det)                     # (tier, cat, Tabl
 ```
 
 Strings and symbols (`":cal"`, `":p03"`, `:r000`) are interchangeable with typed selectors (`DataCategory(:cal)`, `DataPeriod(3)`, `DataRun(0)`).
+
+All shapes work for `:raw`, `:jldsp` and the event tiers in both with-det and no-det form (no-det returns a `NamedTuple` keyed by detector). The per-det tiers (`:jlhit`, `:jlpls`, `:jlpeaks`) require a detector in every shape — no-det forms throw because the file resolver needs the det to find the file.
 
 ### Column selection (`PropSel`)
 

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -65,6 +65,8 @@ The following additional keywords arguments can be set (the `plot_waveform` kwar
 LegendDataManagement provides an extension for [LegendHDF5IO](https://github.com/legend-exp/LegendHDF5IO.jl) that exposes `read_ldata` for loading LEGEND data from HDF5 files. The extension auto-loads when both packages are loaded. All examples assume `$LEGEND_DATA_CONFIG` is set.
 
 ```julia
+ENV["LEGEND_DATA_CONFIG"] = "."
+
 using LegendDataManagement, LegendHDF5IO, PropertyFunctions
 using Unitful: @u_str
 

--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -68,144 +68,182 @@ LegendDataManagement provides an extension for [LegendHDF5IO](https://github.com
 using LegendDataManagement, LegendHDF5IO, PropertyFunctions
 using Unitful: @u_str
 
-l200 = LegendData(:l200)
-fk   = first(search_disk(FileKey, l200.tier[:jldsp, :cal, :p03, :r000]))
-det  = first(filter(c -> c.system == :geds && c.processable, channelinfo(l200, fk))).detector
+l200    = LegendData(:l200)
+fk_cal  = first(search_disk(FileKey, l200.tier[:jldsp, :cal, :p18, :r000]))
+fk_phy  = first(search_disk(FileKey, l200.tier[:raw,   :phy, :p18, :r000]))
+fks_phy = search_disk(FileKey, l200.tier[:raw, :phy, :p18, :r000])
+det     = first(filter(c -> c.system == :geds && c.processable, channelinfo(l200, fk_cal))).detector
 ```
 
-### Selecting columns
+### Tier overview
 
-Three equivalent forms (all return a `Table`):
+| Tier(s) | File layout | `(tier, fk)` no-det | `(tier, fk, det)` with det | `subgroup` | per-det evt slicing |
+|---------|-------------|---------------------|----------------------------|------------|---------------------|
+| `:raw`, `:jldsp`               | shared, struct-view per det | `NamedTuple{det → Table}` (multi-det discovery) | `Table`                                  | ✓ | — |
+| `:jlhit`, `:jlpls`, `:jlpeaks` | one file per `(run, det)`   | — (det is required)                             | `Table`                                  | ✓ | — |
+| `:jlevt`, `:jlskm`             | shared evt-file             | nested LH5 / flat-leaf PropSel                  | flat per-det `Table` (mask + VoV unwrap) | — | GED, SPM |
+| `:jlpmt`                       | shared evt-file             | nested LH5 / flat-leaf PropSel                  | flat per-PMT `Table`                     | — | PMT |
+
+`PropSel`, `filterby`, `filtertier`, and `n_evts` work across all tiers. The detector system (`:geds`, `:spms`, `:pmts`) is auto-detected from `channelinfo` — no need to pass it.
+
+### Call forms
+
+The third positional argument is an `rsel` tuple; you can also spread its elements positionally (`read_ldata(data, tier, args...)`). All forms accept the kwargs from the sections below. Multi-filekey, multi-run, and partition forms additionally accept `parallel=true` and `wpool::WorkerPool`.
 
 ```julia
-read_ldata(l200, :jldsp, fk, det)                                       # all columns
-read_ldata((:e_cusp, :timestamp), l200, (:jldsp, fk, det))              # tuple of names
-read_ldata(@pf((; $e_cusp, $timestamp)), l200, (:jldsp, fk, det))       # PropSel via @pf
+# By filekey
+read_ldata(l200, :jldsp, fk_cal)                              # (tier, fk)              no det → NamedTuple per det
+read_ldata(l200, :jldsp, fk_cal, det)                         # (tier, fk, det)
+read_ldata(l200, :jldsp, fks_phy, det)                        # (tier, [fks], det)      multi-fk
+
+# By period / run (det required for per-det tiers)
+read_ldata(l200, :jldsp, :cal, :p03, det)                     # (tier, cat, period, det)
+read_ldata(l200, :jldsp, :cal, :p03, :r000, det)              # (tier, cat, period, run, det)
+read_ldata(l200, :jldsp, :cal, DataPartition(1), det)         # (tier, cat, partition, det)
+
+# Custom run set (Table with :period and :run columns)
+runs = partitioninfo(l200, det, DataPartition(1))
+read_ldata(l200, :jldsp, :cal, runs, det)                     # (tier, cat, Table{period,run}, det)
 ```
 
-The PropSel form enables a fast path that only loads the requested leaf columns from disk; the tuple form is sugar for the same. A bare `Symbol` (`read_ldata(:e_cusp, l200, …)`) is sugar for `(:e_cusp,)`.
+Strings and symbols (`":cal"`, `":p03"`, `:r000`) are interchangeable with typed selectors (`DataCategory(:cal)`, `DataPeriod(3)`, `DataRun(0)`).
 
-### Per-detector slicing across tiers
+### Column selection (`PropSel`)
 
-`read_ldata(_, l200, (tier, fk, det))` works for `:raw`, `:jldsp`, `:jlhit`, `:jlpls`, `:jlpeaks`, and the event tiers `:jlevt`, `:jlskm`, `:jlpmt`. The detector system (`:geds`, `:spms`, `:pmts`) is auto-detected from `channelinfo` — no need to pass it.
+```julia
+read_ldata(l200, :jldsp, fk_cal, det)                                              # all columns
+read_ldata(:e_cusp, l200, (:jldsp, fk_cal, det))                                   # bare Symbol  → (:e_cusp,)
+read_ldata((:e_cusp, :timestamp), l200, (:jldsp, fk_cal, det))                     # tuple of names
+read_ldata(@pf((; $e_cusp, $timestamp)), l200, (:jldsp, fk_cal, det))              # PropSel via @pf
+read_ldata(@pf((; bltime = $timestamp * $blmean)), l200, (:jldsp, fk_cal, det))  # rename via @pf
+```
 
-| Tier              | With detector                                        | Without detector                       |
-|-------------------|------------------------------------------------------|----------------------------------------|
-| `raw`, `jldsp`    | per-detector Table                                   | NamedTuple of per-detector Tables      |
-| `jlhit`, `jlpls`  | per-detector Table (use `subgroup=` to descend)      | NamedTuple of per-detector Tables      |
-| `jlevt`, `jlskm`  | flat-prefixed Table for that detector                | nested LH5 view (multi-detector)       |
-| `jlpmt`           | per-PMT Table                                        | flat top-level Table (no `geds`/`spms`)|
+`PropSel` triggers a fast path that only loads the requested leaf columns. Combined with `filterby`, the union of source columns is loaded once.
 
-#### Per-detector event-tier read (flat-prefixed)
+### Filtering (`filterby`)
+
+`filterby` takes a `PropertyFunction` evaluated row-wise; rows where the predicate is `missing` are dropped (same as `false`). When `@pf` is used inline as a kwarg, wrap the body in parens — `filterby = @pf(...)` — otherwise the macro stops at the next comma and PropertyFunctions fails with `invalid assignment location`.
+
+```julia
+# Single condition
+read_ldata((:e_cusp,), l200, (:jldsp, fk_cal, det); filterby = @pf($e_cusp > 1000))
+
+# Multi-column cut on a per-det jlevt Table
+read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, fk_phy, det);
+           filterby = @pf($geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV"))
+
+# Cross-subgroup QC: geds + ged_spm + !aux_muonveto + !aux_pulser
+read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, fk_phy, det);
+           filterby = @pf($geds_is_valid_qc && $ged_spm_is_valid_lar &&
+                          !$aux_muonveto_aux_trig && !$aux_pulser_aux_trig))
+```
+
+`@pf $col` (flat source name) enables the fast path; `@pf $a.b.c` (dot-chain) is evaluated on the whole loaded object — use this with the nested no-detector LH5 view.
+
+### Cross-tier filter (`filtertier`)
+
+`filtertier` evaluates `filterby` on a *different* tier than the one being read and slices the target by the derived alignment. Requires a detector.
+
+| Filter source                        | Target                               | Mechanism |
+|--------------------------------------|--------------------------------------|-----------|
+| evt-tier (`jlevt`, `jlskm`, `jlpmt`) | any                                  | per-det `*_detevtno` slicing (`geds_detevtno`, `spms_detevtno`, `detevtno`) |
+| `raw`, `jldsp`                       | non-evt (`raw`, `jldsp`, `jlhit`, …) | per-trigger 1:1 row-aligned `Bool` mask |
+
+| target ↓ \ source →         | `jlevt` | `jlskm` | `jlpmt` | `raw` | `jldsp` |
+|-----------------------------|---------|---------|---------|-------|---------|
+| `jlevt`                     | —       | ✓       | ✓       | ✗     | ✗       |
+| `jlskm`                     | ✓       | —       | ✓       | ✗     | ✗       |
+| `jlpmt`                     | ✓       | ✓       | —       | ✗     | ✗       |
+| `raw`                       | ✓       | ✓       | ✓       | —     | ✓       |
+| `jldsp`                     | ✓       | ✓       | ✓       | ✓     | —       |
+| `jlhit`, `jlpeaks`, `jlpls` | ✓       | ✓       | ✓       | ✓¹    | ✓¹      |
+
+`✗` evt-tier target with non-evt source: rejects with `ArgumentError`. `—` filter tier equals target: skipped. `✓¹` allowed but caller must ensure 1:1 row alignment.
+
+```julia
+# Raw waveforms of phy events that pass an event-tier QC + energy cut
+read_ldata(@pf((; $waveform_presummed, $timestamp)),
+           l200, (:raw, fk_phy, det);
+           filterby   = @pf($geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV"),
+           filtertier = :jlevt)
+
+# jldsp filtered by an event-tier predicate
+read_ldata((:e_cusp, :t50), l200, (:jldsp, fk_phy, det);
+           filterby = @pf($ged_spm_is_valid_lar == true), filtertier = :jlevt)
+
+# Cal raw waveforms with a dsp-energy cut (cal has no jlevt)
+read_ldata((:waveform_presummed,), l200, (:raw, fk_cal, det);
+           filterby = @pf($e_cusp > 1000), filtertier = :jldsp)
+
+# Symmetric direction (jldsp filtered by raw column, e.g. daqenergy)
+read_ldata((:e_cusp,), l200, (:jldsp, fk_phy, det);
+           filterby = @pf($daqenergy > 100), filtertier = :raw)
+```
+
+### Per-detector event-tier reads (`:jlevt`, `:jlskm`, `:jlpmt`)
+
+With a detector, event-tier reads return a flat-prefixed Table whose rows are restricted to events where that detector participated. Per-trigger and per-det-list VoV columns are unwrapped at the detector's slot; scalar columns pass through.
+
+| Tier     | GED | SPM | PMT |
+|----------|-----|-----|-----|
+| `:jlevt` |  ✓  |  ✓  |  ✗  |
+| `:jlskm` |  ✓  |  ✓  |  ✗  |
+| `:jlpmt` |  ✗  |  ✗  |  ✓  |
+
+`✗` throws `no per-det data in <tier> for system :<sys>`. Mask source: `trig_e_det` (per-trigger, preferred for GED) falls back to `detector` (per-det-list, used for SPM/PMT). Cross-system columns (e.g. `ged_spm_*`) are indexed at the matching system's slot via the column's inner-length signature.
 
 ```julia
 read_ldata((:geds_e_cusp_ctc_cal, :geds_trig_e_cusp_ctc_cal),
            l200, (:jlevt, fk_phy, det))
 ```
 
-Columns are flat-prefixed by sub-group: `geds_e_cusp_ctc_cal`, `geds_trig_e_cusp_ctc_cal`, `spms_trig_max_cal`, `aux_pulser_aux_trig`, `ged_spm_is_valid_lar`, … The name-map is built dynamically by walking the HDF5 group, so new sub-groups need no code change. Per-trigger and per-det-list VoVs are unwrapped at the detector's per-event slot, and only events where the detector triggered are kept.
+Columns are flat-prefixed by sub-group: `geds_e_cusp_ctc_cal`, `spms_trig_max_cal`, `aux_pulser_aux_trig`, `ged_spm_is_valid_lar`, etc. The name-map is built dynamically by walking the HDF5 group, so new sub-groups need no code change.
 
-#### No-detector event-tier read (nested LH5)
+### No-detector event-tier reads
+
+Without a detector, event-tier reads return either:
+
+- **flat-leaf PropSel** — when `PropSel` requests only flat leaves (e.g. `:geds_multiplicity`, `:aux_pulser_aux_trig`), only those columns are loaded. No detector mask — every event is returned.
+- **nested LH5** — otherwise (no PropSel, or PropSel asks for a whole sub-group like `:geds`), the native nested layout is preserved (back-compat for callers like `process_evt_phy`).
 
 ```julia
+# Flat-leaf PropSel
+read_ldata((:geds_multiplicity, :aux_forcedtrigger_aux_trig), l200, (:jlevt, fk_phy))
+
+# Nested LH5 view
 evt = read_ldata(l200, :jlevt, fk_phy)
 evt.aux.pulser.aux_trig          # Vector{Bool}
 evt.geds.is_valid_qc             # Vector{Bool}
 evt.geds.detector                # VoV{DetectorId} — per event, list of triggered dets
-evt.geds.e_cusp_ctc_cal          # VoV{Float} — per event, list of energies
+evt.geds.e_cusp_ctc_cal          # VoV{Float}     — per event, list of energies
 ```
 
-The native nested layout is preserved here; this matches the layout `process_evt_phy` etc. expect.
-
-#### Sub-group descent (`subgroup=`)
+### Sub-group descent (`subgroup`)
 
 For tiers that nest data inside per-detector groups (e.g. `jlhit/<det>/dataQC`):
 
 ```julia
 read_ldata(@pf((; $e_cusp, $timestamp)), l200, (:jlhit, fk_cal, det); subgroup=:dataQC)
-read_ldata((:is_physical,),               l200, (:jlhit, fk_cal, det); subgroup=:qc)
-read_ldata((:daqenergy, :timestamp),      l200, (:jlpls, fk_cal, "PULS01"); subgroup=:tags)
+read_ldata((:is_physical,),              l200, (:jlhit, fk_cal, det); subgroup=:qc)
+read_ldata((:daqenergy, :timestamp),     l200, (:jlpls, fk_cal, "PULS01"); subgroup=:tags)
 ```
 
-#### Multi-detector discovery
+The kwarg is ignored on evt-tier reads (which already use a flat-prefixed structure).
 
-Calling `read_ldata(l200, tier, fk)` without a detector on a per-detector tier returns a `NamedTuple` keyed by detector id:
+### Multi-detector discovery
+
+For `:raw` and `:jldsp`, calling without a detector returns a `NamedTuple` keyed by detector ID:
 
 ```julia
 all = read_ldata(l200, :jldsp, fk_cal)      # NamedTuple — all dets in this filekey
 all.B00000C.e_cusp                          # access by detector name
 ```
 
-### Filtering during the read
+Per-det tiers (`:jlhit`, `:jlpls`, `:jlpeaks`) cannot be read this way — they require a det in every call.
 
-`filterby` is a `PropertyFunction` applied row-wise to the loaded table; `missing` predicate values are dropped (same as `false`):
+### Distributed reads
 
-```julia
-# Trigger-energy cut on top of the per-det mask
-read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, fk_phy, det);
-           filterby = @pf $geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV")
-
-# Cross-subgroup QC: geds + ged_spm + !aux_muonveto + !aux_pulser
-read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, fk_phy, det);
-           filterby = @pf $geds_is_valid_qc && $ged_spm_is_valid_lar &&
-                          !$aux_muonveto_aux_trig && !$aux_pulser_aux_trig)
-
-# Bare-bool column: write `== true` (PropertyFunctions doesn't accept `@pf $x` alone)
-read_ldata((:e_cusp,), l200, (:jldsp, fk, det); filterby = @pf $is_valid_muon == true)
-```
-
-#### `@pf` flat names vs dot syntax
-
-- `@pf $geds_is_valid_qc` — single source column → `PropertyFunction` with one named source. The reader can match against on-disk columns and the **fast path** loads only what's needed. Use this with the per-detector flat-prefix Table.
-- `@pf $geds.is_valid_qc == true` — generic `getproperty` chain. Evaluated row-wise on the *whole* loaded object, so the fast path is bypassed. Use this on the no-detector nested LH5 view.
-
-### Cross-tier filter (`filtertier` kwarg)
-
-A per-detector raw/jldsp read can be filtered by a predicate evaluated on a different tier. Two modes, both keyed by the same detector:
-
-- **event tier → raw / jldsp** — slices via the per-det `*_detevtno` column (1-based, same for raw and jldsp). For `geds`: `geds_detevtno`; for `spms`: `spms_detevtno`; for `pmts`: `detevtno`.
-- **raw ↔ jldsp** — uses the 1:1 row alignment between raw and jldsp for a given detector and applies a `Bool` row-mask. Works for `phy` *and* `cal` (the latter has no jlevt — so `:jldsp` is the only useful filtertier there).
-
-```julia
-# Raw waveforms of phy events that pass an event-tier QC + energy cut
-read_ldata(@pf((; $waveform_presummed, $timestamp)),
-           l200, (:raw, fk_phy, det);
-           filterby   = @pf $geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV",
-           filtertier = :jlevt)
-
-# jldsp filtered by an event-tier predicate
-read_ldata((:e_cusp, :t50), l200, (:jldsp, fk_phy, det);
-           filterby   = @pf $ged_spm_is_valid_lar == true,
-           filtertier = :jlevt)
-
-# Cal raw waveforms with a dsp-energy cut (cal has no jlevt)
-read_ldata((:waveform_presummed,), l200, (:raw, fk_cal, det);
-           filterby   = @pf $e_cusp > 1000,
-           filtertier = :jldsp)
-
-# Symmetric direction (jldsp filtered by raw column, e.g. daqenergy)
-read_ldata((:e_cusp,), l200, (:jldsp, fk_phy, det);
-           filterby   = (@pf $daqenergy > 100),
-           filtertier = :raw)
-```
-
-`filtertier` defaults to the current tier (no cross-tier slicing). It requires a detector and rejects non-event tiers as filtertier when the *target* is an event tier.
-
-### Run / period / partition selection
-
-```julia
-read_ldata(l200, :jldsp, fk, det)                            # one filekey
-read_ldata(l200, :jldsp, [fk1, fk2, fk3], det)               # multiple filekeys
-read_ldata(l200, :jldsp, :cal, :p03, :r000, det)             # one run (all filekeys)
-read_ldata(l200, :jldsp, :cal, DataPeriod(3),    det)        # one period
-read_ldata(l200, :jldsp, :cal, DataPartition(1), det)        # one partition
-```
-
-`PropSel`, `filterby` and `filtertier` work the same with all of these.
-
-#### Distributed reads
-
-Multi-filekey selectors accept `parallel=true` and a custom `wpool::WorkerPool`:
+Multi-filekey, multi-run, and partition forms accept `parallel=true` and a custom `wpool::WorkerPool`:
 
 ```julia
 using Distributed
@@ -213,16 +251,15 @@ addprocs(4)
 @everywhere using LegendDataManagement, LegendHDF5IO
 
 read_ldata((:e_cusp,), l200, (:jldsp, fks_phy, det);
-           filterby = @pf $e_cusp > 0, parallel=true)
+           filterby = @pf($e_cusp > 0), parallel=true)
 ```
 
-Workers must have both packages loaded. Without `parallel=true`, a sequential progress bar is shown; with it, `progress_pmap` distributes the per-filekey reads across the worker pool.
+Workers must have both packages loaded. Without `parallel=true`, the per-filekey reads are sequential with a progress bar; with it, `progress_pmap` distributes them across the worker pool.
 
 ### Other kwargs
 
-- `subgroup=:dataQC` — descend into a per-det sub-group (e.g. `jlhit/<det>/dataQC`).
-- `n_evts=1000` — random sample of `n_evts` rows per file (applied after `filterby`).
-- `ignore_missing=true` — return `nothing` instead of throwing when a detector is missing in a file.
+- `n_evts=1000` — limit to `n_evts` rows per file. On `PropSel + filterby` paths, applied after the filter (first `n_evts` survivors); on the eager fallback, may random-sample at load.
+- `ignore_missing=true` — return `nothing` instead of throwing when a detector is missing from a per-det / shared tier file (does not apply to evt-tier reads).
 
 ## `SolidStateDetectors` extension
 

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -298,7 +298,7 @@ function _read_evt_table(h::LegendHDF5IO.LHDataStore, data::LegendData, filekey:
             error("column $name not found in /$tier (available: $(sort(collect(keys(nmap)))))")
         (path, col) = nmap[name]
         masked = getproperty(h[path], col)[:][mask]
-        path == persubdet_path ? _index_col(masked, det_idxs, trig_idxs, det_inner_lens, trig_inner_lens) : masked
+        _index_col(masked, det_idxs, trig_idxs, det_inner_lens, trig_inner_lens)
     end
 
     # Fast path: load only columns referenced by PropSel + filterby.

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -125,6 +125,14 @@ end
 const _evt_tiers = DataTier.([:jlevt, :jlskm, :jlpmt])
 const _perdet_tiers = DataTier.([:jlpeaks, :jlhit, :jlpls])
 
+# For cross-tier filtering: name of the per-det column in an event tier that
+# indexes into raw/jldsp rows for a given system.
+const _evt_idx_col = Dict{Symbol,Symbol}(
+    :geds => :geds_dataidx,
+    :spms => :spms_dataidx,
+    :pmts => :dataidx,
+)
+
 # Inner LH5 path that holds per-detector data (a `detector` or `trig_e_det`
 # VoV) for a given (evt-tier, system) combination. `nothing` ⇒ this combo has
 # no per-det slicing and the caller must reject.
@@ -321,10 +329,26 @@ function _resolve_perdet_path(h, tier::DataTier, det::DetectorId)
     nothing
 end
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey, DetectorIdLike}; filterby::Base.Callable=Returns(true), n_evts::Int=-1, ignore_missing::Bool=false, subgroup::Union{Symbol,Nothing}=nothing, kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey, DetectorIdLike}; filterby::Base.Callable=Returns(true), filtertier::Union{DataTierLike,Nothing}=nothing, n_evts::Int=-1, ignore_missing::Bool=false, subgroup::Union{Symbol,Nothing}=nothing, kwargs...)
     tier, filekey = DataTier(rsel[1]), rsel[2]
     has_det = !isempty(string(rsel[3]))
     det_arg = has_det ? DetectorId(rsel[3]) : nothing
+
+    # Cross-tier filter: get per-det row indices from filtertier (an evt tier),
+    # then load the target tier and slice. dataidx is 1-based for both raw and
+    # jldsp, so it indexes directly without offset.
+    if filtertier !== nothing && DataTier(filtertier) != tier
+        has_det || throw(ArgumentError("filtertier requires a DetectorId"))
+        ftier = DataTier(filtertier)
+        ftier in _evt_tiers || throw(ArgumentError("filtertier must be an event tier (got :$ftier)"))
+        sys = channelinfo(data, filekey, det_arg).system
+        idx_col = get(_evt_idx_col, sys, nothing)
+        idx_col === nothing && throw(ArgumentError("No index column known for system :$sys"))
+        idxs = getproperty(LegendDataManagement.read_ldata((idx_col,), data, (ftier, filekey, det_arg); filterby), idx_col)
+        tbl = LegendDataManagement.read_ldata(f, data, (tier, filekey, det_arg); ignore_missing, subgroup, kwargs...)
+        sliced = tbl[idxs]
+        return n_evts > 0 ? sliced[1:min(n_evts, length(sliced))] : sliced
+    end
 
     _lh5_data_open(data, tier, filekey, det_arg) do h
         if tier in _evt_tiers

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -2,7 +2,6 @@ module LegendDataManagementLegendHDF5IOExt
 
 using LegendDataManagement
 LegendDataManagement._lh5_ext_loaded(::Val{true}) = true
-using LegendDataManagement.LDMUtils: detector2channel, channel2detector
 using LegendDataManagement: RunCategorySelLike
 using LegendHDF5IO
 using LegendDataTypes: fast_flatten, flatten_by_key
@@ -10,38 +9,8 @@ using StructArrays
 using TypedTables, PropertyFunctions
 using Distributed, ProgressMeter
 
-const ChannelOrDetectorIdLike = Union{ChannelIdLike, DetectorIdLike}
-const AbstractDataSelectorLike = Union{AbstractString, Symbol, DataTierLike, DataCategoryLike, DataPeriodLike, DataRunLike, DataPartitionLike, ChannelOrDetectorIdLike}
-const PossibleDataSelectors = [DataTier, DataCategory, DataPeriod, DataRun, DataPartition, ChannelId, DetectorId]
-
-function _is_valid_id_or_tier(data::LegendData, rsel::Union{AnyValiditySelection, RunCategorySelLike}, id::ChannelOrDetectorIdLike)
-    if LegendDataManagement._can_convert_to(ChannelId, id) ||  LegendDataManagement._can_convert_to(DetectorId, id) ||  LegendDataManagement._can_convert_to(DataTier, id)
-        true  
-    else  
-        @warn "Skipped $id since it is neither a valid `ChannelId`, `DetectorId` nor a `DataTier`"  
-        false  
-    end  
-end
-
-function _get_channelid(data::LegendData, rsel::Union{AnyValiditySelection, RunCategorySelLike}, det::ChannelOrDetectorIdLike)
-    if LegendDataManagement._can_convert_to(ChannelId, det)
-        ChannelId(det)
-    elseif LegendDataManagement._can_convert_to(DetectorId, det)
-        detector2channel(data, rsel, det)
-    else
-        throw(ArgumentError("$det is neither a ChannelId nor a DetectorId"))
-    end
-end
-
-function _get_detectorid(data::LegendData, rsel::Union{AnyValiditySelection, RunCategorySelLike}, det::ChannelOrDetectorIdLike)
-    if LegendDataManagement._can_convert_to(DetectorId, det)
-        DetectorId(det)
-    elseif LegendDataManagement._can_convert_to(ChannelId, det)
-        channel2detector(data, rsel, det)
-    else
-        throw(ArgumentError("$det is neither a ChannelId nor a DetectorId"))
-    end
-end
+const AbstractDataSelectorLike = Union{AbstractString, Symbol, DataTierLike, DataCategoryLike, DataPeriodLike, DataRunLike, DataPartitionLike, DetectorIdLike}
+const PossibleDataSelectors = [DataTier, DataCategory, DataPeriod, DataRun, DataPartition, DetectorId]
 
 
 const dataselector_bytypes = Dict{Type, String}()
@@ -146,7 +115,6 @@ function __init__()
     (@isdefined DataCategory) && extend_datatype_dict(DataCategory, "datacategory")
     (@isdefined Timestamp) && extend_datatype_dict(Timestamp, "timestamp")
     (@isdefined FileKey) && extend_datatype_dict(FileKey, "filekey")
-    (@isdefined ChannelId) && extend_datatype_dict(ChannelId, "channelid")
     (@isdefined DetectorId) && extend_datatype_dict(DetectorId, "detectorid")
     (@isdefined DataPartition) && extend_datatype_dict(DataPartition, "datapartition")
 end
@@ -179,16 +147,12 @@ _load_all_keys(x, n_evts::Int=-1) = x
 
 const _evt_tiers = DataTier.([:jlevt, :jlskm])
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey, ChannelOrDetectorIdLike}; filterby::Base.Callable=Returns(true), filtertier::DataTierLike=first(rsel), n_evts::Int=-1, ignore_missing::Bool=false, parallel::Bool=false, wpool::WorkerPool=default_worker_pool())
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey, DetectorIdLike}; filterby::Base.Callable=Returns(true), filtertier::DataTierLike=first(rsel), n_evts::Int=-1, ignore_missing::Bool=false, parallel::Bool=false, wpool::WorkerPool=default_worker_pool())
     tier, filekey = DataTier(rsel[1]), rsel[2]
 
-    det = if !isempty(string((rsel[3])))
-            _get_detectorid(data, rsel[2], rsel[3])
-        else
-            rsel[3]
-    end
+    det = !isempty(string(rsel[3])) ? DetectorId(rsel[3]) : rsel[3]
     det_tier = tier in _evt_tiers ? "/$tier" : "$det/$tier"
-    
+
     data_tier = _lh5_data_open(data, tier, filekey, det) do h
         if !isempty(string(det)) && !(tier in _evt_tiers) && !haskey(h, "$det")
             if ignore_missing
@@ -198,7 +162,7 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
                 throw(ArgumentError("Detector $det not found in $(basename(string(h.data_store)))"))
             end
         end
-        
+
         # load detector data
         if f isa PropSelFunction && filterby == Returns(true)
             # if no filter given optimize performance for property selection functions by only loading required columns
@@ -222,9 +186,9 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
             end
         end
     end
+    # jlevt+det: keep events where the detector triggered (per-event entry in trig_e_det).
     if tier in _evt_tiers && !isempty(string(det))
-        ch = _get_channelid(data, filekey, det)
-        data_tier[any.(map.(isequal(Int(ch)), data_tier.geds.trig_e_ch))]
+        data_tier[any.(map.(isequal(det), data_tier.geds.trig_e_det))]
     else
         data_tier
     end
@@ -234,22 +198,23 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
     ids = _lh5_data_open(data, rsel[1], rsel[2], "") do h
         keys(h)
     end
-    ids = filter(x -> _is_valid_id_or_tier(data, rsel[2], x), ids)
+    # Top-level keys are either the tier itself (event-tier files) or detector ids.
+    valid(x) = LegendDataManagement._can_convert_to(DetectorId, x) ||
+               LegendDataManagement._can_convert_to(DataTier, x)
+    ids = filter(valid, ids)
     @debug "Found keys: $ids"
     if length(ids) == 1
         if string(only(ids)) == string(rsel[1])
             LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], ""); kwargs...)
-        elseif LegendDataManagement._can_convert_to(ChannelId, only(ids)) || LegendDataManagement._can_convert_to(DetectorId, only(ids))
-            LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], string(only(ids))); kwargs...)
         else
-            throw(ArgumentError("No tier channel or detector found in $(basename(string(h.data_store)))"))
+            LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], string(only(ids))); kwargs...)
         end
     else
-        NamedTuple{Tuple(Symbol.(ids))}([LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], ch); kwargs...) for ch in ids])
+        NamedTuple{Tuple(Symbol.(ids))}([LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], d); kwargs...) for d in ids])
     end
 end
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, AbstractVector{FileKey}, ChannelOrDetectorIdLike}; parallel::Bool=false, wpool::WorkerPool=default_worker_pool(), kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, AbstractVector{FileKey}, DetectorIdLike}; parallel::Bool=false, wpool::WorkerPool=default_worker_pool(), kwargs...)
     first_fk = first(rsel[2])
     p = Progress(length(rsel[2]), desc="Reading from $(first_fk.setup)-$(first_fk.period)-$(first_fk.run)-$(first_fk.category)", showspeed=true)
     lflatten(if parallel
@@ -294,32 +259,22 @@ LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{
     LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], rsel[3], rsel[4], ""); kwargs...)
 
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPartition, ChannelOrDetectorIdLike}; kwargs...)
-    first_run = first(LegendDataManagement._get_partitions(data, :default, rsel[2])[rsel[3]])
-    ch = _get_channelid(data, (first_run.period, first_run.run, rsel[2]), rsel[4])
-    pinfo = partitioninfo(data, ch, rsel[3])
-    @assert ch == _get_channelid(data, (first(pinfo).period, first(pinfo).run, rsel[2]), rsel[4]) "Channel mismatch in partitioninfo"
-    LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], pinfo, ch); kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPartition, DetectorIdLike}; kwargs...)
+    pinfo = partitioninfo(data, DetectorId(rsel[4]), rsel[3])
+    LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], pinfo, rsel[4]); kwargs...)
 end
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPeriod, ChannelOrDetectorIdLike}; kwargs...)
-    rinfo = runinfo(data, rsel[3])
-    first_run = first(rinfo)
-    ch = if !isempty(string(rsel[4]))
-        _get_channelid(data, (first_run.period, first_run.run, rsel[2]), rsel[4])
-    else
-        string(rsel[4])
-    end
-    LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], rinfo, ch); kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPeriod, DetectorIdLike}; kwargs...)
+    LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], runinfo(data, rsel[3]), rsel[4]); kwargs...)
 end
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPeriod, DataRun, ChannelOrDetectorIdLike}; kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPeriod, DataRun, DetectorIdLike}; kwargs...)
     fks = search_disk(FileKey, data.tier[rsel[1], rsel[2], rsel[3], rsel[4]])
-    ch = rsel[5]
-    if isempty(fks) && isfile(data.tier[rsel[1:4]..., ch])
-        LegendDataManagement.read_ldata(f, data, (rsel[1], start_filekey(data, (rsel[3], rsel[4], rsel[2])), ch); kwargs...)
+    det = rsel[5]
+    if isempty(fks) && isfile(data.tier[rsel[1:4]..., det])
+        LegendDataManagement.read_ldata(f, data, (rsel[1], start_filekey(data, (rsel[3], rsel[4], rsel[2])), det); kwargs...)
     elseif !isempty(fks)
-        LegendDataManagement.read_ldata(f, data, (rsel[1], fks, ch); kwargs...)
+        LegendDataManagement.read_ldata(f, data, (rsel[1], fks, det); kwargs...)
     else
         throw(ArgumentError("No filekeys found for $(rsel[2]) $(rsel[3]) $(rsel[4])"))
     end
@@ -329,7 +284,7 @@ end
 ### DataPartition
 const _partinfo_required_cols = NamedTuple{(:period, :run), Tuple{DataPeriod, DataRun}}
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, DataCategoryLike, Table{_partinfo_required_cols}, ChannelOrDetectorIdLike}; parallel::Bool=false, wpool::WorkerPool=default_worker_pool(), kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, DataCategoryLike, Table{_partinfo_required_cols}, DetectorIdLike}; parallel::Bool=false, wpool::WorkerPool=default_worker_pool(), kwargs...)
     p = Progress(length(rsel[3]), desc="Reading from $(length(rsel[3])) runs", showspeed=true)
     lflatten(if parallel
                 # TODO: Check if wpool is connected via :master_worker if myid() != 1
@@ -348,7 +303,7 @@ end
 LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, DataCategoryLike, Table{_partinfo_required_cols}}; kwargs...) =
     LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], rsel[3], ""); kwargs...)
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, DataCategoryLike, Table, ChannelOrDetectorIdLike}; kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, DataCategoryLike, Table, DetectorIdLike}; kwargs...)
     @assert (hasproperty(rsel[3], :period) && hasproperty(rsel[3], :run)) "Runtable doesn't provide periods and runs"
     LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], Table(period = rsel[3].period, run = rsel[3].run), rsel[4]); kwargs...)
 end

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -125,12 +125,14 @@ end
 const _evt_tiers = DataTier.([:jlevt, :jlskm, :jlpmt])
 const _perdet_tiers = DataTier.([:jlpeaks, :jlhit, :jlpls])
 
-# For cross-tier filtering: name of the per-det column in an event tier that
-# indexes into raw/jldsp rows for a given system.
+# For cross-tier filtering: per-det event-tier column that gives the 1-based
+# per-(fk, det) row index in raw / jldsp. `detevtno` (per-detector event
+# number) is the right column here. `dataidx` looks similar in some
+# datasets but in others it is a run-wide cumulative offset.
 const _evt_idx_col = Dict{Symbol,Symbol}(
-    :geds => :geds_dataidx,
-    :spms => :spms_dataidx,
-    :pmts => :dataidx,
+    :geds => :geds_detevtno,
+    :spms => :spms_detevtno,
+    :pmts => :detevtno,
 )
 
 # Inner LH5 path that holds per-detector data (a `detector` or `trig_e_det`

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -119,106 +119,121 @@ function __init__()
     (@isdefined DataPartition) && extend_datatype_dict(DataPartition, "datapartition")
 end
 
-function _lh5_data_open(f::Function, data::LegendData, tier::DataTierLike, filekey::FileKey, det::DetectorIdLike, mode::AbstractString="r")
-    det_filename = data.tier[DataTier(tier), filekey, det]
-    filename = data.tier[DataTier(tier), filekey]
-    if isfile(det_filename)
-        @debug "Read from $(basename(det_filename))"
-        LegendHDF5IO.lh5open(f, det_filename, mode)
-    elseif isfile(filename)
-        @debug "Read from $(basename(filename))"
-        LegendHDF5IO.lh5open(f, filename, mode)
+# Tier classes drive dispatch: per-det tiers live in per-detector files; evt
+# tiers in shared files. raw and jldsp aren't listed — they're shared files
+# but reach detectors via inner paths (handled by _resolve_perdet_path).
+const _evt_tiers = DataTier.([:jlevt, :jlskm])
+const _perdet_tiers = DataTier.([:jlpeaks, :jlhit, :jlpls])
+
+# Open the LH5 file for (tier, filekey). Per-det tiers also need a det.
+function _lh5_data_open(f::Function, data::LegendData, tier::DataTierLike, filekey::FileKey, det::Union{DetectorIdLike, Nothing}=nothing, mode::AbstractString="r")
+    t = DataTier(tier)
+    if t in _perdet_tiers
+        isnothing(det) && throw(ArgumentError("DetectorId required for per-detector tier $t"))
+        path = data.tier[t, filekey, DetectorId(det)]
     else
-        throw(ArgumentError("Neither $(basename(filename)) nor $(basename(det_filename)) found"))
+        path = data.tier[t, filekey]
     end
+    LegendHDF5IO.lh5open(f, path, mode)
 end
 
 _skipnothingmissing(xv::AbstractVector) = [x for x in skipmissing(xv) if !isnothing(x)]
 lflatten(x) = fast_flatten(collect(_skipnothingmissing(x)))
 lflatten(nt::AbstractVector{<:NamedTuple}) = flatten_by_key(collect(_skipnothingmissing(nt)))
 
-_propfunc_src_columnnames(f::PropSelFunction{src_cols, trg_cols}) where {src_cols, trg_cols} = src_cols
-_propfunc_trg_columnnames(f::PropSelFunction{src_cols, trg_cols}) where {src_cols, trg_cols} = trg_cols
+# Source-column names for any PropertyFunction (incl. filterby); target-column
+# names only for PropSelFunction (the only kind that renames on read).
+_propfunc_src_columnnames(::PropertyFunctions.PropertyFunction{names}) where names = names
+_propfunc_src_columnnames(::Any) = ()
+_propfunc_trg_columnnames(::PropSelFunction{src, trg}) where {src, trg} = trg
 
 _load_all_keys(nt::NamedTuple, n_evts::Int=-1) = if length(nt) == 1 _load_all_keys(nt[first(keys(nt))], n_evts) else NamedTuple{keys(nt)}(map(x -> _load_all_keys(nt[x], n_evts), keys(nt))) end
 _load_all_keys(arr::AbstractArray, n_evts::Int=-1) = arr[:][if (n_evts < 1 || n_evts > length(arr)) 1:length(arr) else rand(1:length(arr), n_evts) end]
 _load_all_keys(t::Table, n_evts::Int=-1) = t[:][if (n_evts < 1 || n_evts > length(t)) 1:length(t) else rand(1:length(t), n_evts) end]
 _load_all_keys(x, n_evts::Int=-1) = x
 
-const _evt_tiers = DataTier.([:jlevt, :jlskm])
-
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey, DetectorIdLike}; filterby::Base.Callable=Returns(true), filtertier::DataTierLike=first(rsel), n_evts::Int=-1, ignore_missing::Bool=false, parallel::Bool=false, wpool::WorkerPool=default_worker_pool())
-    tier, filekey = DataTier(rsel[1]), rsel[2]
-
-    det = !isempty(string(rsel[3])) ? DetectorId(rsel[3]) : rsel[3]
-    det_tier = tier in _evt_tiers ? "/$tier" : "$det/$tier"
-
-    data_tier = _lh5_data_open(data, tier, filekey, det) do h
-        if !isempty(string(det)) && !(tier in _evt_tiers) && !haskey(h, "$det")
-            if ignore_missing
-                @warn "Detector $det not found in $(basename(string(h.data_store)))"
-                return nothing
-            else
-                throw(ArgumentError("Detector $det not found in $(basename(string(h.data_store)))"))
-            end
-        end
-
-        # load detector data
-        if f isa PropSelFunction && filterby == Returns(true)
-            # if no filter given optimize performance for property selection functions by only loading required columns
-            Table(if length(_propfunc_src_columnnames(f)) == 1
-                NamedTuple{_propfunc_trg_columnnames(f)}([_load_all_keys(getproperty(only(_propfunc_src_columnnames(f)))(h[det_tier]), n_evts)])
-            else
-                NamedTuple{_propfunc_trg_columnnames(f)}(Tuple(values(columns(_load_all_keys(getproperties(_propfunc_src_columnnames(f))(h[det_tier]), n_evts)))))
-            end)
+# Apply PropSel / filterby / identity to a loaded HDF5 node. Filter is
+# missing-tolerant: rows where filterby returns missing are dropped.
+function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::Int)
+    if f isa PropSelFunction && filterby == Returns(true)
+        # PropSel-only fast path: load just the requested leaf columns.
+        src_cols = _propfunc_src_columnnames(f)
+        trg_cols = _propfunc_trg_columnnames(f)
+        Table(if length(src_cols) == 1
+            NamedTuple{trg_cols}([_load_all_keys(getproperty(only(src_cols))(h_node), n_evts)])
         else
-            lh5_data = _load_all_keys(h[det_tier], n_evts)
-            if filterby != Returns(true)
-                lh5_data = lh5_data |> PropertyFunctions.filterby(filterby)
+            NamedTuple{trg_cols}(Tuple(values(columns(_load_all_keys(getproperties(src_cols)(h_node), n_evts)))))
+        end)
+    else
+        lh5_data = _load_all_keys(h_node, n_evts)
+        if filterby != Returns(true)
+            lh5_data = lh5_data[coalesce.(filterby.(lh5_data), false)]
+        end
+        f != identity && (lh5_data = f.(lh5_data))
+        TypedTables.Tables.istable(lh5_data) ? Table(lh5_data) : lh5_data
+    end
+end
+
+# Resolve the inner HDF5 path for (tier, det). Primary: "tier/det" (current
+# layout). Fallback: "det/tier" (legacy). "tier" alone covers struct-view files
+# like raw/jldsp where the per-det entry is itself the tier root.
+function _resolve_perdet_path(h, tier::DataTier, det::DetectorId)
+    haskey(h, "$tier/$det") && return "$tier/$det"
+    haskey(h, "$det/$tier") && return "$det/$tier"
+    haskey(h, "$tier")      && return "$tier"
+    nothing
+end
+
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey, DetectorIdLike}; filterby::Base.Callable=Returns(true), n_evts::Int=-1, ignore_missing::Bool=false, subgroup::Union{Symbol,Nothing}=nothing, kwargs...)
+    tier, filekey = DataTier(rsel[1]), rsel[2]
+    has_det = !isempty(string(rsel[3]))
+    det_arg = has_det ? DetectorId(rsel[3]) : nothing
+
+    data_tier = _lh5_data_open(data, tier, filekey, det_arg) do h
+        if tier in _evt_tiers
+            # Evt-tier no-det reads return the whole tier table; per-det reads
+            # are post-filtered below to events where the detector triggered.
+            _apply_read(h["$tier"], f, filterby, n_evts)
+        else
+            has_det || throw(ArgumentError("DetectorId required for tier $tier"))
+            path = _resolve_perdet_path(h, tier, det_arg)
+            if path === nothing
+                ignore_missing && (@warn "Detector $det_arg not found in $(basename(string(h.data_store)))"; return nothing)
+                throw(ArgumentError("Detector $det_arg not found in $(basename(string(h.data_store)))"))
             end
-            if f != identity
-                lh5_data = f.(lh5_data)
-            end
-            if TypedTables.Tables.istable(lh5_data)
-                Table(lh5_data)
-            else
-                lh5_data
-            end
+            # Optional descent into a sub-group (e.g. jlhit/<det>/dataQC).
+            full = subgroup === nothing ? path : "$path/$subgroup"
+            haskey(h, full) || throw(ArgumentError("Subgroup $subgroup not found at $path in $(basename(string(h.data_store)))"))
+            _apply_read(h[full], f, filterby, n_evts)
         end
     end
-    # jlevt+det: keep events where the detector triggered (per-event entry in trig_e_det).
-    if tier in _evt_tiers && !isempty(string(det))
-        data_tier[any.(map.(isequal(det), data_tier.geds.trig_e_det))]
+    if tier in _evt_tiers && has_det
+        data_tier[any.(map.(isequal(det_arg), data_tier.geds.trig_e_det))]
     else
         data_tier
     end
 end
 
 function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey}; kwargs...)
-    ids = _lh5_data_open(data, rsel[1], rsel[2], "") do h
-        keys(h)
-    end
-    # Top-level keys are either the tier itself (event-tier files) or detector ids.
-    valid(x) = LegendDataManagement._can_convert_to(DetectorId, x) ||
-               LegendDataManagement._can_convert_to(DataTier, x)
-    ids = filter(valid, ids)
-    @debug "Found keys: $ids"
-    if length(ids) == 1
-        if string(only(ids)) == string(rsel[1])
-            LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], ""); kwargs...)
+    tier = DataTier(rsel[1])
+    tier in _evt_tiers && return LegendDataManagement.read_ldata(f, data, (tier, rsel[2], ""); kwargs...)
+    # Per-det tiers and shared raw/jldsp: list detectors. Primary "tier/<det>"
+    # listing falls back to the legacy "<det>/tier" layout (top-level keys).
+    dets = _lh5_data_open(data, tier, rsel[2]) do h
+        if haskey(h, "$tier")
+            collect(keys(h["$tier"]))
         else
-            LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], string(only(ids))); kwargs...)
+            [k for k in keys(h) if haskey(h, "$k/$tier")]
         end
-    else
-        NamedTuple{Tuple(Symbol.(ids))}([LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], d); kwargs...) for d in ids])
     end
+    isempty(dets) && throw(ArgumentError("No detectors found under /$tier in $(basename(data.tier[tier, rsel[2]]))"))
+    NamedTuple{Tuple(Symbol.(dets))}([LegendDataManagement.read_ldata(f, data, (tier, rsel[2], d); kwargs...) for d in dets])
 end
 
 function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, AbstractVector{FileKey}, DetectorIdLike}; parallel::Bool=false, wpool::WorkerPool=default_worker_pool(), kwargs...)
     first_fk = first(rsel[2])
     p = Progress(length(rsel[2]), desc="Reading from $(first_fk.setup)-$(first_fk.period)-$(first_fk.run)-$(first_fk.category)", showspeed=true)
     lflatten(if parallel
-                # TODO: Check if wpool is connected via :master_worker if myid() != 1
                 @debug "Parallel read with $(length(workers())) workers from $(length(rsel[2])) filekeys"
                 progress_pmap(wpool, rsel[2]; progress=p) do fk
                     LegendDataManagement.read_ldata(f, data, ifelse(!isempty(string(rsel[3])), (rsel[1], fk, rsel[3]),  (rsel[1], fk)); kwargs...)
@@ -236,6 +251,10 @@ LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{
 ### Argument distinction for different DataSelector Types
 function _convert_rsel2dsel(rsel::NTuple{<:Any, AbstractDataSelectorLike})
     selector_types = [PossibleDataSelectors[LegendDataManagement._can_convert_to.(PossibleDataSelectors, Ref(s))] for s in rsel]
+    # Disambiguate: a tier symbol like :raw also parses as a generic Symbol.
+    if length(selector_types[1]) > 1 && DataTier in selector_types[1]
+        selector_types[1] = [DataTier]
+    end
     if length(selector_types[2]) > 1 && DataCategory in selector_types[2]
         selector_types[2] = [DataCategory]
     end
@@ -269,15 +288,13 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
 end
 
 function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPeriod, DataRun, DetectorIdLike}; kwargs...)
-    fks = search_disk(FileKey, data.tier[rsel[1], rsel[2], rsel[3], rsel[4]])
-    det = rsel[5]
-    if isempty(fks) && isfile(data.tier[rsel[1:4]..., det])
-        LegendDataManagement.read_ldata(f, data, (rsel[1], start_filekey(data, (rsel[3], rsel[4], rsel[2])), det); kwargs...)
-    elseif !isempty(fks)
-        LegendDataManagement.read_ldata(f, data, (rsel[1], fks, det); kwargs...)
-    else
-        throw(ArgumentError("No filekeys found for $(rsel[2]) $(rsel[3]) $(rsel[4])"))
-    end
+    tier = DataTier(rsel[1])
+    # Per-det tiers: one file per (run, det) → resolve via start_filekey rather
+    # than search_disk (whose tier-dir scan would miss the per-det layout).
+    tier in _perdet_tiers && return LegendDataManagement.read_ldata(f, data, (tier, start_filekey(data, (rsel[3], rsel[4], rsel[2])), rsel[5]); kwargs...)
+    fks = search_disk(FileKey, data.tier[tier, rsel[2], rsel[3], rsel[4]])
+    isempty(fks) && throw(ArgumentError("No filekeys found for $(rsel[2]) $(rsel[3]) $(rsel[4])"))
+    LegendDataManagement.read_ldata(f, data, (tier, fks, rsel[5]); kwargs...)
 end
 
 

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -122,8 +122,21 @@ end
 # Tier classes drive dispatch: per-det tiers live in per-detector files; evt
 # tiers in shared files. raw and jldsp aren't listed — they're shared files
 # but reach detectors via inner paths (handled by _resolve_perdet_path).
-const _evt_tiers = DataTier.([:jlevt, :jlskm])
+const _evt_tiers = DataTier.([:jlevt, :jlskm, :jlpmt])
 const _perdet_tiers = DataTier.([:jlpeaks, :jlhit, :jlpls])
+
+# Inner LH5 path that holds per-detector data (a `detector` or `trig_e_det`
+# VoV) for a given (evt-tier, system) combination. `nothing` ⇒ this combo has
+# no per-det slicing and the caller must reject.
+function _evt_persubdet_path(tier::DataTier, sys::Symbol)
+    if tier == DataTier(:jlevt) || tier == DataTier(:jlskm)
+        sys == :geds && return "$tier/geds"
+        sys == :spms && return "$tier/spms"
+    elseif tier == DataTier(:jlpmt)
+        sys == :pmts && return "$tier"
+    end
+    return nothing
+end
 
 # Open the LH5 file for (tier, filekey). Per-det tiers also need a det.
 function _lh5_data_open(f::Function, data::LegendData, tier::DataTierLike, filekey::FileKey, det::Union{DetectorIdLike, Nothing}=nothing, mode::AbstractString="r")
@@ -174,6 +187,130 @@ function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::
     end
 end
 
+# Walk an event-tier HDF5 group into a flat name-map
+# `prefix_name => (h5_path, leaf_col_symbol)`. Top-level scalars/VoVs keep
+# their bare name; sub-table columns are namespaced as `<sub>_<col>` (e.g.
+# `aux/pulser/aux_trig` → `aux_pulser_aux_trig`). VoV groups are detected
+# via the `cumulative_length` / `encoded_data` markers and treated as leaves.
+function _build_evt_namemap(h::LegendHDF5IO.LHDataStore, tier::DataTier)
+    nmap = Dict{Symbol, Tuple{String, Symbol}}()
+    h5_grp = h.data_store["$tier"]
+    try
+        _walk_evt_h5!(nmap, h5_grp, "$tier", "")
+    finally
+        close(h5_grp)
+    end
+    nmap
+end
+
+function _walk_evt_h5!(out::Dict, group, base_path::String, prefix::String)
+    for k in keys(group)
+        full_name = isempty(prefix) ? Symbol(k) : Symbol(prefix, "_", k)
+        child = group[k]
+        try
+            if child isa LegendHDF5IO.HDF5.Dataset
+                out[full_name] = (base_path, Symbol(k))
+            elseif child isa LegendHDF5IO.HDF5.Group
+                ck = keys(child)
+                if "cumulative_length" in ck || "encoded_data" in ck
+                    out[full_name] = (base_path, Symbol(k))
+                else
+                    new_prefix = isempty(prefix) ? string(k) : "$(prefix)_$(k)"
+                    _walk_evt_h5!(out, child, "$base_path/$k", new_prefix)
+                end
+            end
+        finally
+            close(child)
+        end
+    end
+end
+
+# Index a per-event column at the detector's per-event slot. Per-trigger and
+# per-det-list VoVs are distinguished by matching the materialized inner
+# lengths against the two reference length vectors; columns whose shape
+# matches neither (or are scalar) are returned as-is.
+function _index_col(col, det_idxs, trig_idxs, det_inner_lens, trig_inner_lens)
+    eltype(col) <: AbstractVector || return col
+    inner_lens = length.(col)
+    if det_inner_lens !== nothing && inner_lens == det_inner_lens
+        return [col[k][det_idxs[k]] for k in eachindex(col)]
+    elseif trig_inner_lens !== nothing && inner_lens == trig_inner_lens
+        return [col[k][trig_idxs[k]] for k in eachindex(col)]
+    else
+        return col
+    end
+end
+
+# Read a flat-prefixed event-tier table for one detector. Mask = events where
+# the detector is present; preferred via `trig_e_det` (per-trigger view, GEDs)
+# and falling back to `detector` (SPMs/PMTs). For surviving events, per-det-
+# list and per-trigger VoV columns are unwrapped at the detector's index;
+# event-scalar columns from any sub-group ride through unchanged.
+function _read_evt_table(h::LegendHDF5IO.LHDataStore, data::LegendData, filekey::FileKey,
+        tier::DataTier, det::DetectorId, f::Base.Callable,
+        filterby::Base.Callable, n_evts::Int)
+
+    nmap = _build_evt_namemap(h, tier)
+
+    sys = channelinfo(data, filekey, det).system
+    persubdet_path = _evt_persubdet_path(tier, sys)
+    persubdet_path === nothing &&
+        error("read_ldata(:$tier, ..., $det): no per-det data in $tier for system :$sys")
+    haskey(h, persubdet_path) ||
+        error("read_ldata(:$tier, ..., $det): /$persubdet_path missing in file")
+    psd = h[persubdet_path]
+
+    # Per-event slot of `det`: from `trig_e_det` if present (drops events
+    # where the detector did not trigger), else from `detector`. Either way
+    # the chosen list also defines the event mask.
+    mask = nothing
+    det_idxs = trig_idxs = nothing
+    det_inner_lens = trig_inner_lens = nothing
+    if hasproperty(psd, :trig_e_det)
+        tl = getproperty(psd, :trig_e_det)[:]
+        keep = [findfirst(isequal(det), t) for t in tl]
+        mask = .!isnothing.(keep)
+        trig_idxs = Int.(keep[mask])
+        trig_inner_lens = length.(tl[mask])
+    end
+    if hasproperty(psd, :detector)
+        dl = getproperty(psd, :detector)[:]
+        keep = [findfirst(isequal(det), t) for t in dl]
+        mask === nothing && (mask = .!isnothing.(keep))
+        det_idxs = Int.(keep[mask])
+        det_inner_lens = length.(dl[mask])
+    end
+    mask === nothing &&
+        error("read_ldata(:$tier, ..., $det): /$persubdet_path has neither :detector nor :trig_e_det")
+
+    function load_col(name::Symbol)
+        haskey(nmap, name) ||
+            error("column $name not found in /$tier (available: $(sort(collect(keys(nmap)))))")
+        (path, col) = nmap[name]
+        masked = getproperty(h[path], col)[:][mask]
+        path == persubdet_path ? _index_col(masked, det_idxs, trig_idxs, det_inner_lens, trig_inner_lens) : masked
+    end
+
+    # Fast path: load only columns referenced by PropSel + filterby.
+    if f isa PropSelFunction && (filterby isa PropertyFunctions.PropertyFunction || filterby === Returns(true))
+        src_cols = _propfunc_src_columnnames(f)
+        trg_cols = _propfunc_trg_columnnames(f)
+        filt_cols = _propfunc_src_columnnames(filterby)
+        needed = Tuple(unique((src_cols..., filt_cols...)))
+        cols = map(load_col, needed)
+        tbl = Table(NamedTuple{needed}(cols))
+        filt_tbl = filterby === Returns(true) ? tbl : tbl[coalesce.(filterby.(tbl), false)]
+        n_evts > 0 && (filt_tbl = filt_tbl[1:min(n_evts, length(filt_tbl))])
+        out_cols = Tuple(getproperty(filt_tbl, c) for c in src_cols)
+        return Table(NamedTuple{trg_cols}(out_cols))
+    end
+
+    # Eager fallback: materialize every column, then apply f / filterby.
+    all_names = Tuple(sort(collect(keys(nmap))))
+    cols = map(load_col, all_names)
+    _apply_read(Table(NamedTuple{all_names}(cols)), f, filterby, n_evts)
+end
+
 # Resolve the inner HDF5 path for (tier, det). Primary: "tier/det" (current
 # layout). Fallback: "det/tier" (legacy). "tier" alone covers struct-view files
 # like raw/jldsp where the per-det entry is itself the tier root.
@@ -189,11 +326,12 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
     has_det = !isempty(string(rsel[3]))
     det_arg = has_det ? DetectorId(rsel[3]) : nothing
 
-    data_tier = _lh5_data_open(data, tier, filekey, det_arg) do h
+    _lh5_data_open(data, tier, filekey, det_arg) do h
         if tier in _evt_tiers
-            # Evt-tier no-det reads return the whole tier table; per-det reads
-            # are post-filtered below to events where the detector triggered.
-            _apply_read(h["$tier"], f, filterby, n_evts)
+            # No-det → return the native nested LH5 (e.g. evt.aux.pulser.aux_trig).
+            # With-det → flat-prefixed table from _read_evt_table.
+            has_det || return _apply_read(h["$tier"], f, filterby, n_evts)
+            _read_evt_table(h, data, filekey, tier, det_arg, f, filterby, n_evts)
         else
             has_det || throw(ArgumentError("DetectorId required for tier $tier"))
             path = _resolve_perdet_path(h, tier, det_arg)
@@ -206,11 +344,6 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
             haskey(h, full) || throw(ArgumentError("Subgroup $subgroup not found at $path in $(basename(string(h.data_store)))"))
             _apply_read(h[full], f, filterby, n_evts)
         end
-    end
-    if tier in _evt_tiers && has_det
-        data_tier[any.(map.(isequal(det_arg), data_tier.geds.trig_e_det))]
-    else
-        data_tier
     end
 end
 

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -334,19 +334,30 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
     has_det = !isempty(string(rsel[3]))
     det_arg = has_det ? DetectorId(rsel[3]) : nothing
 
-    # Cross-tier filter: get per-det row indices from filtertier (an evt tier),
-    # then load the target tier and slice. dataidx is 1-based for both raw and
-    # jldsp, so it indexes directly without offset.
+    # Cross-tier filter. Two cases by filtertier kind:
+    #  • event tier → uses *_dataidx (1-based) to index into the target tier
+    #  • per-trigger tier (raw/jldsp) → relies on 1:1 row alignment with the
+    #    target raw/jldsp file for the same det, applies a Bool row-mask
     if filtertier !== nothing && DataTier(filtertier) != tier
         has_det || throw(ArgumentError("filtertier requires a DetectorId"))
         ftier = DataTier(filtertier)
-        ftier in _evt_tiers || throw(ArgumentError("filtertier must be an event tier (got :$ftier)"))
-        sys = channelinfo(data, filekey, det_arg).system
-        idx_col = get(_evt_idx_col, sys, nothing)
-        idx_col === nothing && throw(ArgumentError("No index column known for system :$sys"))
-        idxs = getproperty(LegendDataManagement.read_ldata((idx_col,), data, (ftier, filekey, det_arg); filterby), idx_col)
-        tbl = LegendDataManagement.read_ldata(f, data, (tier, filekey, det_arg); ignore_missing, subgroup, kwargs...)
-        sliced = tbl[idxs]
+        sliced = if ftier in _evt_tiers
+            sys = channelinfo(data, filekey, det_arg).system
+            idx_col = get(_evt_idx_col, sys, nothing)
+            idx_col === nothing && throw(ArgumentError("No index column known for system :$sys"))
+            idxs = getproperty(LegendDataManagement.read_ldata((idx_col,), data, (ftier, filekey, det_arg); filterby), idx_col)
+            tbl = LegendDataManagement.read_ldata(f, data, (tier, filekey, det_arg); ignore_missing, subgroup, kwargs...)
+            tbl[idxs]
+        elseif !(tier in _evt_tiers)
+            filt_cols = _propfunc_src_columnnames(filterby)
+            isempty(filt_cols) && throw(ArgumentError("filterby must be a @pf PropertyFunction with named source columns"))
+            ft_data = LegendDataManagement.read_ldata(filt_cols, data, (ftier, filekey, det_arg))
+            mask = coalesce.(filterby.(ft_data), false)
+            tbl = LegendDataManagement.read_ldata(f, data, (tier, filekey, det_arg); ignore_missing, subgroup, kwargs...)
+            tbl[mask]
+        else
+            throw(ArgumentError("Cannot use non-event filtertier :$ftier when reading event tier :$tier"))
+        end
         return n_evts > 0 ? sliced[1:min(n_evts, length(sliced))] : sliced
     end
 

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -119,25 +119,16 @@ function __init__()
     (@isdefined DataPartition) && extend_datatype_dict(DataPartition, "datapartition")
 end
 
-# Tier classes drive dispatch: per-det tiers live in per-detector files; evt
-# tiers in shared files. raw and jldsp aren't listed — they're shared files
-# but reach detectors via inner paths (handled by _resolve_perdet_path).
 const _evt_tiers = DataTier.([:jlevt, :jlskm, :jlpmt])
 const _perdet_tiers = DataTier.([:jlpeaks, :jlhit, :jlpls])
 
-# For cross-tier filtering: per-det event-tier column that gives the 1-based
-# per-(fk, det) row index in raw / jldsp. `detevtno` (per-detector event
-# number) is the right column here. `dataidx` looks similar in some
-# datasets but in others it is a run-wide cumulative offset.
+# Per-(fk, det) row index into raw/jldsp; *_dataidx can be run-wide so we use *_detevtno.
 const _evt_idx_col = Dict{Symbol,Symbol}(
     :geds => :geds_detevtno,
     :spms => :spms_detevtno,
     :pmts => :detevtno,
 )
 
-# Inner LH5 path that holds per-detector data (a `detector` or `trig_e_det`
-# VoV) for a given (evt-tier, system) combination. `nothing` ⇒ this combo has
-# no per-det slicing and the caller must reject.
 function _evt_persubdet_path(tier::DataTier, sys::Symbol)
     if tier == DataTier(:jlevt) || tier == DataTier(:jlskm)
         sys == :geds && return "$tier/geds"
@@ -148,7 +139,6 @@ function _evt_persubdet_path(tier::DataTier, sys::Symbol)
     return nothing
 end
 
-# Open the LH5 file for (tier, filekey). Per-det tiers also need a det.
 function _lh5_data_open(f::Function, data::LegendData, tier::DataTierLike, filekey::FileKey, det::Union{DetectorIdLike, Nothing}=nothing, mode::AbstractString="r")
     t = DataTier(tier)
     if t in _perdet_tiers
@@ -164,22 +154,32 @@ _skipnothingmissing(xv::AbstractVector) = [x for x in skipmissing(xv) if !isnoth
 lflatten(x) = fast_flatten(collect(_skipnothingmissing(x)))
 lflatten(nt::AbstractVector{<:NamedTuple}) = flatten_by_key(collect(_skipnothingmissing(nt)))
 
-# Source-column names for any PropertyFunction (incl. filterby); target-column
-# names only for PropSelFunction (the only kind that renames on read).
 _propfunc_src_columnnames(::PropertyFunctions.PropertyFunction{names}) where names = names
 _propfunc_src_columnnames(::Any) = ()
 _propfunc_trg_columnnames(::PropSelFunction{src, trg}) where {src, trg} = trg
 
-_load_all_keys(nt::NamedTuple, n_evts::Int=-1) = if length(nt) == 1 _load_all_keys(nt[first(keys(nt))], n_evts) else NamedTuple{keys(nt)}(map(x -> _load_all_keys(nt[x], n_evts), keys(nt))) end
-_load_all_keys(arr::AbstractArray, n_evts::Int=-1) = arr[:][if (n_evts < 1 || n_evts > length(arr)) 1:length(arr) else rand(1:length(arr), n_evts) end]
-_load_all_keys(t::Table, n_evts::Int=-1) = t[:][if (n_evts < 1 || n_evts > length(t)) 1:length(t) else rand(1:length(t), n_evts) end]
+_sample_idx(n::Int, n_evts::Int) = (n_evts < 1 || n_evts > n) ? (1:n) : rand(1:n, n_evts)
+
+function _load_all_keys(nt::NamedTuple, n_evts::Int=-1)
+    length(nt) == 1 && return _load_all_keys(nt[first(keys(nt))], n_evts)
+    NamedTuple{keys(nt)}(map(k -> _load_all_keys(nt[k], n_evts), keys(nt)))
+end
+_load_all_keys(arr::AbstractArray, n_evts::Int=-1) = arr[:][_sample_idx(length(arr), n_evts)]
+_load_all_keys(t::Table, n_evts::Int=-1) = t[:][_sample_idx(length(t), n_evts)]
 _load_all_keys(x, n_evts::Int=-1) = x
 
-# Apply PropSel / filterby / identity to a loaded HDF5 node. Filter is
-# missing-tolerant: rows where filterby returns missing are dropped.
+function _propsel_filter_apply(load_col, f::PropSelFunction, filterby::Base.Callable, n_evts::Int)
+    src    = _propfunc_src_columnnames(f)
+    trg    = _propfunc_trg_columnnames(f)
+    needed = Tuple(unique((src..., _propfunc_src_columnnames(filterby)...)))
+    tbl    = Table(NamedTuple{needed}(map(load_col, needed)))
+    filterby !== Returns(true) && (tbl = tbl[coalesce.(filterby.(tbl), false)])
+    n_evts > 0 && (tbl = tbl[1:min(n_evts, length(tbl))])
+    Table(NamedTuple{trg}(Tuple(getproperty(tbl, c) for c in src)))
+end
+
 function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::Int)
     if f isa PropSelFunction && filterby == Returns(true)
-        # PropSel-only fast path: load just the requested leaf columns.
         src_cols = _propfunc_src_columnnames(f)
         trg_cols = _propfunc_trg_columnnames(f)
         Table(if length(src_cols) == 1
@@ -188,18 +188,7 @@ function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::
             NamedTuple{trg_cols}(Tuple(values(columns(_load_all_keys(getproperties(src_cols)(h_node), n_evts)))))
         end)
     elseif f isa PropSelFunction && filterby isa PropertyFunctions.PropertyFunction
-        # PropSel + filterby fast path: load only the union of source columns
-        # referenced by the projection and the filter, then mask + project.
-        src_cols  = _propfunc_src_columnnames(f)
-        trg_cols  = _propfunc_trg_columnnames(f)
-        filt_cols = _propfunc_src_columnnames(filterby)
-        needed    = Tuple(unique((src_cols..., filt_cols...)))
-        loaded   = _load_all_keys(getproperties(needed)(h_node), -1)
-        tbl      = Table(loaded)
-        filt_tbl = tbl[coalesce.(filterby.(tbl), false)]
-        n_evts > 0 && (filt_tbl = filt_tbl[1:min(n_evts, length(filt_tbl))])
-        out_cols = Tuple(getproperty(filt_tbl, c) for c in src_cols)
-        return Table(NamedTuple{trg_cols}(out_cols))
+        return _propsel_filter_apply(name -> getproperty(h_node, name)[:], f, filterby, n_evts)
     else
         lh5_data = _load_all_keys(h_node, n_evts)
         if filterby != Returns(true)
@@ -210,11 +199,7 @@ function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::
     end
 end
 
-# Walk an event-tier HDF5 group into a flat name-map
-# `prefix_name => (h5_path, leaf_col_symbol)`. Top-level scalars/VoVs keep
-# their bare name; sub-table columns are namespaced as `<sub>_<col>` (e.g.
-# `aux/pulser/aux_trig` → `aux_pulser_aux_trig`). VoV groups are detected
-# via the `cumulative_length` / `encoded_data` markers and treated as leaves.
+# Flatten LH5 group into `prefix_name => (h5_path, leaf)`; VoV groups (cumulative_length / encoded_data) are leaves.
 function _build_evt_namemap(h::LegendHDF5IO.LHDataStore, tier::DataTier)
     nmap = Dict{Symbol, Tuple{String, Symbol}}()
     h5_grp = h.data_store["$tier"]
@@ -248,10 +233,7 @@ function _walk_evt_h5!(out::Dict, group, base_path::String, prefix::String)
     end
 end
 
-# Index a per-event column at the detector's per-event slot. Per-trigger and
-# per-det-list VoVs are distinguished by matching the materialized inner
-# lengths against the two reference length vectors; columns whose shape
-# matches neither (or are scalar) are returned as-is.
+# Dispatch per-trigger vs per-det-list VoV by inner-length signature; scalar/other cols pass through.
 function _index_col(col, det_idxs, trig_idxs, det_inner_lens, trig_inner_lens)
     eltype(col) <: AbstractVector || return col
     inner_lens = length.(col)
@@ -264,11 +246,7 @@ function _index_col(col, det_idxs, trig_idxs, det_inner_lens, trig_inner_lens)
     end
 end
 
-# Read a flat-prefixed event-tier table for one detector. Mask = events where
-# the detector is present; preferred via `trig_e_det` (per-trigger view, GEDs)
-# and falling back to `detector` (SPMs/PMTs). For surviving events, per-det-
-# list and per-trigger VoV columns are unwrapped at the detector's index;
-# event-scalar columns from any sub-group ride through unchanged.
+# Per-det flat-prefixed evt-tier read. Mask via `trig_e_det` (preferred, GEDs) or `detector` (SPMs/PMTs).
 function _read_evt_table(h::LegendHDF5IO.LHDataStore, data::LegendData, filekey::FileKey,
         tier::DataTier, det::DetectorId, f::Base.Callable,
         filterby::Base.Callable, n_evts::Int)
@@ -283,9 +261,6 @@ function _read_evt_table(h::LegendHDF5IO.LHDataStore, data::LegendData, filekey:
         error("read_ldata(:$tier, ..., $det): /$persubdet_path missing in file")
     psd = h[persubdet_path]
 
-    # Per-event slot of `det`: from `trig_e_det` if present (drops events
-    # where the detector did not trigger), else from `detector`. Either way
-    # the chosen list also defines the event mask.
     mask = nothing
     det_idxs = trig_idxs = nothing
     det_inner_lens = trig_inner_lens = nothing
@@ -314,65 +289,25 @@ function _read_evt_table(h::LegendHDF5IO.LHDataStore, data::LegendData, filekey:
         _index_col(masked, det_idxs, trig_idxs, det_inner_lens, trig_inner_lens)
     end
 
-    # Fast path: load only columns referenced by PropSel + filterby.
-    if f isa PropSelFunction && (filterby isa PropertyFunctions.PropertyFunction || filterby === Returns(true))
-        src_cols = _propfunc_src_columnnames(f)
-        trg_cols = _propfunc_trg_columnnames(f)
-        filt_cols = _propfunc_src_columnnames(filterby)
-        needed = Tuple(unique((src_cols..., filt_cols...)))
-        cols = map(load_col, needed)
-        tbl = Table(NamedTuple{needed}(cols))
-        filt_tbl = filterby === Returns(true) ? tbl : tbl[coalesce.(filterby.(tbl), false)]
-        n_evts > 0 && (filt_tbl = filt_tbl[1:min(n_evts, length(filt_tbl))])
-        out_cols = Tuple(getproperty(filt_tbl, c) for c in src_cols)
-        return Table(NamedTuple{trg_cols}(out_cols))
-    end
+    f isa PropSelFunction && (filterby isa PropertyFunctions.PropertyFunction || filterby === Returns(true)) &&
+        return _propsel_filter_apply(load_col, f, filterby, n_evts)
 
-    # Eager fallback: materialize every column, then apply f / filterby.
     all_names = Tuple(sort(collect(keys(nmap))))
     cols = map(load_col, all_names)
     _apply_read(Table(NamedTuple{all_names}(cols)), f, filterby, n_evts)
 end
 
-# No-detector counterpart to `_read_evt_table`. Builds the same flat-prefixed
-# `nmap` (e.g. `geds_multiplicity`, `aux_pulser_aux_trig`) so PropSel can
-# request individual leaf columns instead of whole top-level sub-groups.
-# No detector mask / per-det-slot unwrap — every event is returned and per-det
-# VoV columns ride through as VoV.
+# No-detector evt-tier read: per-leaf PropSel via flat nmap; falls back to nested LH5 for back-compat.
 function _read_evt_no_det_table(h::LegendHDF5IO.LHDataStore, tier::DataTier,
         f::Base.Callable, filterby::Base.Callable, n_evts::Int)
-
-    # Without PropSel, keep the legacy nested-NamedTuple behaviour so callers
-    # that rely on `evt.aux.pulser.aux_trig` (or load all of jlevt) are unaffected.
     f isa PropSelFunction || return _apply_read(h["$tier"], f, filterby, n_evts)
-
     nmap = _build_evt_namemap(h, tier)
-    src_cols  = _propfunc_src_columnnames(f)
-    filt_cols = _propfunc_src_columnnames(filterby)
-    needed    = Tuple(unique((src_cols..., filt_cols...)))
-
-    # Fall back to top-level PropSel if any requested column is not a leaf in
-    # nmap (e.g. caller asked for `:geds` to grab the whole sub-group).
-    all(c -> haskey(nmap, c), needed) ||
-        return _apply_read(h["$tier"], f, filterby, n_evts)
-
-    function load_col(name::Symbol)
-        path, col = nmap[name]
-        return getproperty(h[path], col)[:]
-    end
-
-    trg_cols  = _propfunc_trg_columnnames(f)
-    cols      = map(load_col, needed)
-    tbl       = Table(NamedTuple{needed}(cols))
-    filt_tbl  = filterby === Returns(true) ? tbl : tbl[coalesce.(filterby.(tbl), false)]
-    n_evts > 0 && (filt_tbl = filt_tbl[1:min(n_evts, length(filt_tbl))])
-    out_cols  = Tuple(getproperty(filt_tbl, c) for c in src_cols)
-    return Table(NamedTuple{trg_cols}(out_cols))
+    needed = Tuple(unique((_propfunc_src_columnnames(f)..., _propfunc_src_columnnames(filterby)...)))
+    all(c -> haskey(nmap, c), needed) || return _apply_read(h["$tier"], f, filterby, n_evts)
+    _propsel_filter_apply(name -> getproperty(h[nmap[name][1]], nmap[name][2])[:], f, filterby, n_evts)
 end
 
-# Resolve the inner HDF5 path for (tier, det). Primary: "tier/det" (current
-# layout). Fallback: "det/tier" (legacy). "tier" alone covers struct-view files
-# like raw/jldsp where the per-det entry is itself the tier root.
+# Try "tier/det" (current), then "det/tier" (legacy), then bare "tier" (raw/jldsp struct-view).
 function _resolve_perdet_path(h, tier::DataTier, det::DetectorId)
     haskey(h, "$tier/$det") && return "$tier/$det"
     haskey(h, "$det/$tier") && return "$det/$tier"
@@ -385,10 +320,7 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
     has_det = !isempty(string(rsel[3]))
     det_arg = has_det ? DetectorId(rsel[3]) : nothing
 
-    # Cross-tier filter. Two cases by filtertier kind:
-    #  • event tier → uses *_dataidx (1-based) to index into the target tier
-    #  • per-trigger tier (raw/jldsp) → relies on 1:1 row alignment with the
-    #    target raw/jldsp file for the same det, applies a Bool row-mask
+    # Cross-tier filter: event-tier filtertier slices via *_detevtno; per-trigger filtertier (raw/jldsp) uses a row-aligned Bool mask.
     if filtertier !== nothing && DataTier(filtertier) != tier
         has_det || throw(ArgumentError("filtertier requires a DetectorId"))
         ftier = DataTier(filtertier)
@@ -414,10 +346,6 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
 
     _lh5_data_open(data, tier, filekey, det_arg) do h
         if tier in _evt_tiers
-            # No-det → flat-prefixed table from _read_evt_no_det_table when
-            # PropSel is given (column-level granularity); else the native
-            # nested LH5 (back-compat: e.g. evt.aux.pulser.aux_trig).
-            # With-det → flat-prefixed table from _read_evt_table.
             has_det || return _read_evt_no_det_table(h, tier, f, filterby, n_evts)
             _read_evt_table(h, data, filekey, tier, det_arg, f, filterby, n_evts)
         else
@@ -427,7 +355,6 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
                 ignore_missing && (@warn "Detector $det_arg not found in $(basename(string(h.data_store)))"; return nothing)
                 throw(ArgumentError("Detector $det_arg not found in $(basename(string(h.data_store)))"))
             end
-            # Optional descent into a sub-group (e.g. jlhit/<det>/dataQC).
             full = subgroup === nothing ? path : "$path/$subgroup"
             haskey(h, full) || throw(ArgumentError("Subgroup $subgroup not found at $path in $(basename(string(h.data_store)))"))
             _apply_read(h[full], f, filterby, n_evts)
@@ -438,8 +365,7 @@ end
 function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey}; kwargs...)
     tier = DataTier(rsel[1])
     tier in _evt_tiers && return LegendDataManagement.read_ldata(f, data, (tier, rsel[2], ""); kwargs...)
-    # Per-det tiers and shared raw/jldsp: list detectors. Primary "tier/<det>"
-    # listing falls back to the legacy "<det>/tier" layout (top-level keys).
+    # List detectors via "tier/<det>" (current) or fall back to "<det>/tier" (legacy).
     dets = _lh5_data_open(data, tier, rsel[2]) do h
         if haskey(h, "$tier")
             collect(keys(h["$tier"]))
@@ -469,10 +395,8 @@ end
 LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, AbstractVector{FileKey}}; kwargs...) = 
     LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], ""); kwargs...)
 
-### Argument distinction for different DataSelector Types
 function _convert_rsel2dsel(rsel::NTuple{<:Any, AbstractDataSelectorLike})
     selector_types = [PossibleDataSelectors[LegendDataManagement._can_convert_to.(PossibleDataSelectors, Ref(s))] for s in rsel]
-    # Disambiguate: a tier symbol like :raw also parses as a generic Symbol.
     if length(selector_types[1]) > 1 && DataTier in selector_types[1]
         selector_types[1] = [DataTier]
     end
@@ -510,8 +434,7 @@ end
 
 function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTier, DataCategory, DataPeriod, DataRun, DetectorIdLike}; kwargs...)
     tier = DataTier(rsel[1])
-    # Per-det tiers: one file per (run, det) → resolve via start_filekey rather
-    # than search_disk (whose tier-dir scan would miss the per-det layout).
+    # Per-det tiers use start_filekey since search_disk's tier-dir scan misses the per-det layout.
     tier in _perdet_tiers && return LegendDataManagement.read_ldata(f, data, (tier, start_filekey(data, (rsel[3], rsel[4], rsel[2])), rsel[5]); kwargs...)
     fks = search_disk(FileKey, data.tier[tier, rsel[2], rsel[3], rsel[4]])
     isempty(fks) && throw(ArgumentError("No filekeys found for $(rsel[2]) $(rsel[3]) $(rsel[4])"))
@@ -525,7 +448,6 @@ const _partinfo_required_cols = NamedTuple{(:period, :run), Tuple{DataPeriod, Da
 function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, DataCategoryLike, Table{_partinfo_required_cols}, DetectorIdLike}; parallel::Bool=false, wpool::WorkerPool=default_worker_pool(), kwargs...)
     p = Progress(length(rsel[3]), desc="Reading from $(length(rsel[3])) runs", showspeed=true)
     lflatten(if parallel
-                # TODO: Check if wpool is connected via :master_worker if myid() != 1
                 @debug "Parallel read with $(length(workers())) workers from $(length(rsel[3])) runs"
                 progress_pmap(wpool, rsel[3]; progress=p) do r
                     LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], r.period, r.run, rsel[4]); parallel, wpool, kwargs...)

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -307,7 +307,7 @@ function _read_evt_no_det_table(h::LegendHDF5IO.LHDataStore, tier::DataTier,
     _propsel_filter_apply(name -> getproperty(h[nmap[name][1]], nmap[name][2])[:], f, filterby, n_evts)
 end
 
-_is_valid_detid(s::AbstractString) = try DetectorId(s); true catch; false end
+_is_valid_detid(s) = try DetectorId(s); true catch; false end
 
 # Try "tier/det" (current), then "det/tier" (legacy), then bare "tier" (raw/jldsp struct-view).
 function _resolve_perdet_path(h, tier::DataTier, det::DetectorId)

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -307,6 +307,8 @@ function _read_evt_no_det_table(h::LegendHDF5IO.LHDataStore, tier::DataTier,
     _propsel_filter_apply(name -> getproperty(h[nmap[name][1]], nmap[name][2])[:], f, filterby, n_evts)
 end
 
+_is_valid_detid(s::AbstractString) = try DetectorId(s); true catch; false end
+
 # Try "tier/det" (current), then "det/tier" (legacy), then bare "tier" (raw/jldsp struct-view).
 function _resolve_perdet_path(h, tier::DataTier, det::DetectorId)
     haskey(h, "$tier/$det") && return "$tier/$det"
@@ -368,9 +370,9 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
     # List detectors via "tier/<det>" (current) or fall back to "<det>/tier" (legacy).
     dets = _lh5_data_open(data, tier, rsel[2]) do h
         if haskey(h, "$tier")
-            collect(keys(h["$tier"]))
+            filter(_is_valid_detid, collect(keys(h["$tier"])))
         else
-            [k for k in keys(h) if h.data_store[k] isa LegendHDF5IO.HDF5.Group && haskey(h, "$k/$tier")]
+            [k for k in keys(h) if h.data_store[k] isa LegendHDF5IO.HDF5.Group && _is_valid_detid(k) && haskey(h, "$k/$tier")]
         end
     end
     isempty(dets) && throw(ArgumentError("No detectors found under /$tier in $(basename(data.tier[tier, rsel[2]]))"))

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -370,7 +370,7 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
         if haskey(h, "$tier")
             collect(keys(h["$tier"]))
         else
-            [k for k in keys(h) if haskey(h, "$k/$tier")]
+            [k for k in keys(h) if h.data_store[k] isa LegendHDF5IO.HDF5.Group && haskey(h, "$k/$tier")]
         end
     end
     isempty(dets) && throw(ArgumentError("No detectors found under /$tier in $(basename(data.tier[tier, rsel[2]]))"))

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -307,8 +307,6 @@ function _read_evt_no_det_table(h::LegendHDF5IO.LHDataStore, tier::DataTier,
     _propsel_filter_apply(name -> getproperty(h[nmap[name][1]], nmap[name][2])[:], f, filterby, n_evts)
 end
 
-_is_valid_detid(s) = try DetectorId(s); true catch; false end
-
 # Try "tier/det" (current), then "det/tier" (legacy), then bare "tier" (raw/jldsp struct-view).
 function _resolve_perdet_path(h, tier::DataTier, det::DetectorId)
     haskey(h, "$tier/$det") && return "$tier/$det"
@@ -370,9 +368,9 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
     # List detectors via "tier/<det>" (current) or fall back to "<det>/tier" (legacy).
     dets = _lh5_data_open(data, tier, rsel[2]) do h
         if haskey(h, "$tier")
-            filter(_is_valid_detid, collect(keys(h["$tier"])))
+            collect(keys(h["$tier"]))
         else
-            [k for k in keys(h) if h.data_store[k] isa LegendHDF5IO.HDF5.Group && _is_valid_detid(k) && haskey(h, "$k/$tier")]
+            [k for k in keys(h) if h.data_store[k] isa LegendHDF5IO.HDF5.Group && haskey(h, "$k/$tier")]
         end
     end
     isempty(dets) && throw(ArgumentError("No detectors found under /$tier in $(basename(data.tier[tier, rsel[2]]))"))

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -187,6 +187,19 @@ function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::
         else
             NamedTuple{trg_cols}(Tuple(values(columns(_load_all_keys(getproperties(src_cols)(h_node), n_evts)))))
         end)
+    elseif f isa PropSelFunction && filterby isa PropertyFunctions.PropertyFunction
+        # PropSel + filterby fast path: load only the union of source columns
+        # referenced by the projection and the filter, then mask + project.
+        src_cols  = _propfunc_src_columnnames(f)
+        trg_cols  = _propfunc_trg_columnnames(f)
+        filt_cols = _propfunc_src_columnnames(filterby)
+        needed    = Tuple(unique((src_cols..., filt_cols...)))
+        loaded   = _load_all_keys(getproperties(needed)(h_node), -1)
+        tbl      = Table(loaded)
+        filt_tbl = tbl[coalesce.(filterby.(tbl), false)]
+        n_evts > 0 && (filt_tbl = filt_tbl[1:min(n_evts, length(filt_tbl))])
+        out_cols = Tuple(getproperty(filt_tbl, c) for c in src_cols)
+        return Table(NamedTuple{trg_cols}(out_cols))
     else
         lh5_data = _load_all_keys(h_node, n_evts)
         if filterby != Returns(true)
@@ -321,6 +334,42 @@ function _read_evt_table(h::LegendHDF5IO.LHDataStore, data::LegendData, filekey:
     _apply_read(Table(NamedTuple{all_names}(cols)), f, filterby, n_evts)
 end
 
+# No-detector counterpart to `_read_evt_table`. Builds the same flat-prefixed
+# `nmap` (e.g. `geds_multiplicity`, `aux_pulser_aux_trig`) so PropSel can
+# request individual leaf columns instead of whole top-level sub-groups.
+# No detector mask / per-det-slot unwrap — every event is returned and per-det
+# VoV columns ride through as VoV.
+function _read_evt_no_det_table(h::LegendHDF5IO.LHDataStore, tier::DataTier,
+        f::Base.Callable, filterby::Base.Callable, n_evts::Int)
+
+    # Without PropSel, keep the legacy nested-NamedTuple behaviour so callers
+    # that rely on `evt.aux.pulser.aux_trig` (or load all of jlevt) are unaffected.
+    f isa PropSelFunction || return _apply_read(h["$tier"], f, filterby, n_evts)
+
+    nmap = _build_evt_namemap(h, tier)
+    src_cols  = _propfunc_src_columnnames(f)
+    filt_cols = _propfunc_src_columnnames(filterby)
+    needed    = Tuple(unique((src_cols..., filt_cols...)))
+
+    # Fall back to top-level PropSel if any requested column is not a leaf in
+    # nmap (e.g. caller asked for `:geds` to grab the whole sub-group).
+    all(c -> haskey(nmap, c), needed) ||
+        return _apply_read(h["$tier"], f, filterby, n_evts)
+
+    function load_col(name::Symbol)
+        path, col = nmap[name]
+        return getproperty(h[path], col)[:]
+    end
+
+    trg_cols  = _propfunc_trg_columnnames(f)
+    cols      = map(load_col, needed)
+    tbl       = Table(NamedTuple{needed}(cols))
+    filt_tbl  = filterby === Returns(true) ? tbl : tbl[coalesce.(filterby.(tbl), false)]
+    n_evts > 0 && (filt_tbl = filt_tbl[1:min(n_evts, length(filt_tbl))])
+    out_cols  = Tuple(getproperty(filt_tbl, c) for c in src_cols)
+    return Table(NamedTuple{trg_cols}(out_cols))
+end
+
 # Resolve the inner HDF5 path for (tier, det). Primary: "tier/det" (current
 # layout). Fallback: "det/tier" (legacy). "tier" alone covers struct-view files
 # like raw/jldsp where the per-det entry is itself the tier root.
@@ -365,9 +414,11 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
 
     _lh5_data_open(data, tier, filekey, det_arg) do h
         if tier in _evt_tiers
-            # No-det → return the native nested LH5 (e.g. evt.aux.pulser.aux_trig).
+            # No-det → flat-prefixed table from _read_evt_no_det_table when
+            # PropSel is given (column-level granularity); else the native
+            # nested LH5 (back-compat: e.g. evt.aux.pulser.aux_trig).
             # With-det → flat-prefixed table from _read_evt_table.
-            has_det || return _apply_read(h["$tier"], f, filterby, n_evts)
+            has_det || return _read_evt_no_det_table(h, tier, f, filterby, n_evts)
             _read_evt_table(h, data, filekey, tier, det_arg, f, filterby, n_evts)
         else
             has_det || throw(ArgumentError("DetectorId required for tier $tier"))

--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -368,9 +368,10 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
     # List detectors via "tier/<det>" (current) or fall back to "<det>/tier" (legacy).
     dets = _lh5_data_open(data, tier, rsel[2]) do h
         if haskey(h, "$tier")
-            collect(keys(h["$tier"]))
+            filter(k -> LegendDataManagement._can_convert_to(DetectorId, k), collect(keys(h["$tier"])))
         else
-            [k for k in keys(h) if h.data_store[k] isa LegendHDF5IO.HDF5.Group && haskey(h, "$k/$tier")]
+            [k for k in keys(h) if h.data_store[k] isa LegendHDF5IO.HDF5.Group &&
+                LegendDataManagement._can_convert_to(DetectorId, k) && haskey(h, "$k/$tier")]
         end
     end
     isempty(dets) && throw(ArgumentError("No detectors found under /$tier in $(basename(data.tier[tier, rsel[2]]))"))


### PR DESCRIPTION
Refactor `read_ldata` to drop `ChannelId` from its public API, add
per-detector slicing on event tiers (`:jlevt`, `:jlskm`, `:jlpmt`),
and introduce a cross-tier filter via the `filtertier` kwarg.
`LegendHDF5IO` extension docs are updated to match.

## Changes

1. **`DetectorId` throughout.** `read_ldata` accepts `DetectorIdLike` only.
   Channel helpers (`_get_channelid`, `_get_detectorid`,
   `_is_valid_id_or_tier`) and the channel-consistency check in the
   partition method are removed.
2. **Tier classification.** `_evt_tiers = [:jlevt, :jlskm, :jlpmt]` and
   `_perdet_tiers = [:jlpeaks, :jlhit, :jlpls]` drive dispatch. raw and
   jldsp use `_resolve_perdet_path`, which tries `tier/<det>` (current),
   `<det>/tier` (legacy), and `tier` (struct-view) in order.
3. **Per-detector event-tier slicing.** With a detector,
   `read_ldata(_, l200, (:jlevt, fk, det))` returns a flat-prefixed Table
   (`geds_e_cusp_ctc_cal`, `geds_trig_e_cusp_ctc_cal`,
   `aux_pulser_aux_trig`, `ged_spm_is_valid_lar`, …). The name-map is
   built dynamically by walking the HDF5 group; per-trigger and
   per-det-list VoVs are distinguished by their inner-length signature
   and unwrapped at the detector's per-event slot.
4. **Cross-tier filter.** A new `filtertier` kwarg lets a per-detector
   raw/jldsp read be filtered by an event-tier predicate (slicing via
   the per-det `*_dataidx` column, 1-based for raw and jldsp) or by a
   sibling per-trigger-tier predicate (1:1 row alignment per detector).
   Works for phy and cal.
5. **Sub-group descent.** `subgroup=:dataQC` for
   `tier/<det>/group`-style layouts (e.g. jlhit).
6. **Missing-tolerant filter.** Rows where `filterby` returns `missing`
   are dropped (same semantics as `false`).

## What now works

```julia
# Per-detector event-tier read with a trigger-energy cut
read_ldata(@pf((; $geds_e_cusp_ctc_cal, $geds_t50)), l200, (:jlevt, fk, det);
           filterby = @pf $geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV")

# Cross-subgroup QC filter (geds + ged_spm + !aux_muonveto + !aux_pulser)
read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, fk, det);
           filterby = @pf $geds_is_valid_qc && $ged_spm_is_valid_lar &&
                          !$aux_muonveto_aux_trig && !$aux_pulser_aux_trig)

# Raw waveforms of phy events that pass an event-level QC + energy cut
read_ldata(@pf((; $waveform_presummed)), l200, (:raw, fk_phy, det);
           filterby   = @pf $geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV",
           filtertier = :jlevt)

# Cal raw waveforms with a dsp-energy cut (no jlevt for cal)
read_ldata((:waveform_presummed,), l200, (:raw, fk_cal, det);
           filterby   = @pf $e_cusp > 1000,
           filtertier = :jldsp)
```

## Backward-compat note

`read_ldata(l200, :jlevt, fk)` (no detector) still returns the native
nested LH5 view (`evt.aux.pulser.aux_trig`). Filters there use dot syntax
(`@pf $geds.is_valid_qc == true`); flat-prefix names exist only on the
per-detector side.

## Performance

PropSel + `filterby` + `filtertier` fast-path vs. eager-load-then-filter
on real L200 data (FK p18-r000, B00000C, min of 3 trials):

| Case                                              | speed-up | memory  |
|---------------------------------------------------|---------:|--------:|
| A — raw column selection (waveforms)              |     1.3× |    2.1× |
| B — jldsp column + filter (`e_cusp > 0`)          |     1.0× |    1.0× |
| C — jlevt event-scalar filter (cross-subgroup QC) |    40.0× |   42.3× |
| D — jlevt trigger-energy filter (`>1500 keV`)     |    33.7× |   31.7× |
| E — cross-tier (`filtertier=:jlevt`, phy)         |    32.4× |   26.0× |
| F — cross-tier (`filtertier=:jldsp`, cal)         |     1.6× |    2.0× |

The big wins (C–E) come from never materializing the ~1.3 GB full
`jlevt+det` Table when only a handful of columns are needed. Per-det
raw/dsp reads (A, B, F) are smaller files to begin with, so the
absolute numbers are modest but still favorable.

## MCE

```julia
ENV["LEGEND_DATA_CONFIG"] = "/path/to/your/config.json"
using LegendDataManagement, LegendHDF5IO, PropertyFunctions
using Unitful: @u_str

l200    = LegendData(:l200)
PER, RUN = DataPeriod(18), DataRun(0)
fks_phy = search_disk(FileKey, l200.tier[:raw, :phy, PER, RUN])
fks_cal = search_disk(FileKey, l200.tier[:raw, :cal, PER, RUN])
FK_PHY, FK_CAL = first(fks_phy), first(fks_cal)
chinfo  = channelinfo(l200, FK_PHY)
DET_GED = first(filter(c -> c.system == :geds && c.processable, chinfo)).detector
DET_SPM = first(filter(c -> c.system == :spms, chinfo)).detector

# --- Column selection: three equivalent forms ----------------------------
read_ldata(l200, :jldsp, FK_PHY, DET_GED)                                # full
read_ldata((:e_cusp, :timestamp), l200, (:jldsp, FK_PHY, DET_GED))       # tuple
read_ldata(@pf((; $e_cusp, $timestamp)), l200, (:jldsp, FK_PHY, DET_GED))# @pf

# --- Per-detector across tiers (system auto-detected) --------------------
read_ldata((:waveform_presummed,), l200, (:raw,   FK_PHY, DET_GED))
read_ldata((:waveform_bit_drop,),  l200, (:raw,   FK_PHY, DET_SPM))
read_ldata((:e_cusp, :t50),        l200, (:jldsp, FK_PHY, DET_GED))
read_ldata((:e_cusp,),             l200, (:jlhit, FK_CAL, DET_GED); subgroup=:dataQC)
read_ldata((:daqenergy,),          l200, (:jlpls, FK_CAL, "PULS01");  subgroup=:tags)

# --- Event tier with detector → flat-prefixed Table ----------------------
read_ldata((:geds_e_cusp_ctc_cal, :geds_trig_e_cusp_ctc_cal),
           l200, (:jlevt, FK_PHY, DET_GED))

# Trigger-energy cut + cross-subgroup QC, all on flat names
read_ldata(@pf((; $geds_e_cusp_ctc_cal, $geds_t50)),
           l200, (:jlevt, FK_PHY, DET_GED);
           filterby = @pf $geds_is_valid_qc && $ged_spm_is_valid_lar &&
                          !$aux_muonveto_aux_trig && $geds_trig_e_cusp_ctc_cal > 20u"keV")

# --- Event tier without detector → native nested LH5 (use dots) ----------
# Note: the flat-prefix names (geds_is_valid_qc, …) only exist with a det.
# Without a det, use dot-syntax — `@pf $geds_is_valid_qc` would error,
# `@pf $geds.is_valid_qc == true` works (generic getproperty path).
evt = read_ldata(l200, :jlevt, FK_PHY;
                 filterby = @pf $geds.is_valid_qc == true)
evt.geds.e_cusp_ctc_cal       # VoV — per event, list of energies
evt.aux.pulser.aux_trig       # Vector{Bool}

# Old call style still works:
read_ldata((:tags,), l200, DataTier(:jlpls), :phy, partinfo, det_puls)

# --- Cross-tier filter (filtertier kwarg) --------------------------------
# (1) raw waveforms of events passing a jlevt QC + energy cut (phy)
read_ldata(@pf((; $waveform_presummed, $timestamp)), l200, (:raw, FK_PHY, DET_GED);
           filterby   = @pf $geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV",
           filtertier = :jlevt)

# (2) cal raw filtered via cal jldsp (no jlevt for cal)
read_ldata((:waveform_presummed,), l200, (:raw, FK_CAL, DET_GED);
           filterby   = (@pf $e_cusp > 1000),
           filtertier = :jldsp)

# (3) symmetric — jldsp filtered via raw
read_ldata((:e_cusp,), l200, (:jldsp, FK_PHY, DET_GED);
           filterby   = (@pf $daqenergy > 100),
           filtertier = :raw)

# --- Multi-filekey, period, partition ------------------------------------
read_ldata((:e_cusp,), l200, (:jldsp, fks_cal[1:3], DET_GED))
read_ldata((:e_cusp,), l200, (:jldsp, :phy, PER, RUN, DET_GED))
read_ldata((:e_cusp,), l200, (:jldsp, :phy, DataPartition(1), DET_GED))

# Distributed: parallel=true after addprocs + @everywhere using …
# read_ldata((:e_cusp,), l200, (:jldsp, fks_phy, DET_GED); parallel=true)

# --- Other kwargs --------------------------------------------------------
read_ldata((:e_cusp,), l200, (:jldsp, FK_PHY, DET_GED); n_evts=1000)
read_ldata((:e_cusp,), l200, (:jldsp, FK_PHY, "DOESNOTEXIST"); ignore_missing=true)
```

