### PR TITLE
Add allow_cylindrical_asymmetry

### DIFF
--- a/ext/LegendDataManagementSolidStateDetectorsExt.jl
+++ b/ext/LegendDataManagementSolidStateDetectorsExt.jl
@@ -38,6 +38,7 @@ methods above. Uses LEGEND defaults, such as ADLChargeDriftModel2016.
 * `n_thickness::Number`: Thickness of the n+ contact in mm. Accepts units, if non are given will interpret as `mm`. If not provided, it will be taken from the metadata if available or defaulted.
 * `verbose::Bool`: Whether to print detailed information during the creation process. Default is `true`.
 * `save_ssd_config::Bool`: Whether to save the SSD configuration to a YAML file. Default is `false`.
+* `allow_cylindrical_asymmetry::Bool`: Whether to allow geometry features that break the cylindrical (azimuthal) symmetry of the detector, such as a `crack` defined in the metadata `geometry.extra`. When `true` (default) and such a feature is present, the affected volume is cut from the semiconductor and contacts and the simulation grid is switched to a full 3D azimuthal range (`phi` from `0` to `360`). When `false`, these features are ignored and the simulation remains 2D (azimuthally symmetric).
 """
 
 function SolidStateDetectors.SolidStateDetector(data::LegendData, detector::DetectorIdLike, env::HPGeEnvironment = HPGeEnvironment(); kwargs...)
@@ -92,6 +93,7 @@ methods above. Uses LEGEND defaults, such as ADLChargeDriftModel2016.
 * `operational_voltage::Number`: Operational voltage for the n+ contact. Accepts units, if non are given will interpret as `V`. If not provided, it will be taken from the metadata if available or defaulted.
 * `n_thickness::Number`: Thickness of the n+ contact in mm. Accepts units, if non are given will interpret as `mm`. If not provided, it will be taken from the metadata if available or defaulted.
 * `verbose::Bool`: Whether to print detailed information during the creation process. Default is `true`.
+* `allow_cylindrical_asymmetry::Bool`: Whether to allow geometry features that break the cylindrical (azimuthal) symmetry of the detector, such as a `crack` defined in the metadata `geometry.extra`. When `true` (default) and such a feature is present, the affected volume is cut from the semiconductor and contacts and the simulation grid is switched to a full 3D azimuthal range (`phi` from `0` to `360`). When `false`, these features are ignored and the simulation remains 2D (azimuthally symmetric).
 
 """
 function SolidStateDetectors.Simulation(data::LegendData, detector::DetectorIdLike, env::HPGeEnvironment = HPGeEnvironment(); kwargs...)
@@ -242,7 +244,7 @@ function get_taper_mantle_parts(dicttype, α, h, r_bot, r_top, z, li_thickness)
 end
 
 function create_SSD_config_dict_from_LEGEND_metadata(diode_meta::PropDict, xtal_meta::X, env::HPGeEnvironment = HPGeEnvironment(); 
-    dicttype = OrderedDict{String,Any}, verbose::Bool = true, operational_voltage::Number = NaN, n_thickness::Number = NaN, use_impurity_corrections::Bool = true, ssd_config_filename::Union{Missing, AbstractString} = missing) where {X <: Union{PropDict, LegendDataManagement.NoSuchPropsDBEntry}}
+    dicttype = OrderedDict{String,Any}, verbose::Bool = true, operational_voltage::Number = NaN, n_thickness::Number = NaN, use_impurity_corrections::Bool = true, allow_cylindrical_asymmetry::Bool = true, ssd_config_filename::Union{Missing, AbstractString} = missing) where {X <: Union{PropDict, LegendDataManagement.NoSuchPropsDBEntry}}
 
     # Not all possible configurations are yet implemented!
     gap = 1.0 # to ensure negative volumes do not match at surfaces
@@ -783,7 +785,7 @@ function create_SSD_config_dict_from_LEGEND_metadata(diode_meta::PropDict, xtal_
     end
 
     if haskey(geo, :extra) 
-        if haskey(geo.extra, :crack)
+        if allow_cylindrical_asymmetry && haskey(geo.extra, :crack)
             
             # cut the crack volume from the semiconductor
             radius_crack = geo.extra.crack.radius_in_mm

--- a/test/test_ext_ssd.jl
+++ b/test/test_ext_ssd.jl
@@ -81,6 +81,27 @@ include("testing_utils.jl")
         end
     end
 
+    @testset "Test allow_cylindrical_asymmetry" begin
+        n = 1.0
+        T = Float32
+        diode_meta_crack = LegendDataManagement.readlprops("test_config_files/V00000A_crack.yaml")
+        xtal_meta = LegendDataManagement.readlprops("test_config_files/V00000.yaml")
+
+        # With a crack and asymmetry allowed (default), the simulation is switched to full 3D
+        sim_asym = Simulation{T}(LegendData, diode_meta_crack, xtal_meta, n_thickness = n)
+        @test sim_asym.config_dict["grid"]["axes"]["phi"]["to"] == 360
+
+        # With asymmetry disallowed, the crack is ignored and the grid stays azimuthally symmetric
+        sim_sym = Simulation{T}(LegendData, diode_meta_crack, xtal_meta, n_thickness = n, allow_cylindrical_asymmetry = false)
+        @test sim_sym.config_dict["grid"]["axes"]["phi"]["to"] == 0
+
+        # Disabling the crack restores the full (uncracked) semiconductor volume
+        x, z = (diode_meta_crack.geometry.radius_in_mm - 2n, 2n) ./ 1000
+        point = CartesianPoint{T}(x, 0, z)
+        @test !(point in sim_asym.detector.semiconductor)
+        @test point in sim_sym.detector.semiconductor
+    end
+
     @testset "Test HPGeEnvironment" begin
         detname = :V99000A
         env = LegendDataManagement.HPGeEnvironment("LAr", 87u"K")


### PR DESCRIPTION
## Summary
- Add `allow_cylindrical_asymmetry` keyword. Default is set to `true`:

Whether to allow geometry features that break the cylindrical (azimuthal) symmetry of the detector, such as a `crack` defined in the metadata `geometry.extra`. When `true` (default) and such a feature is present, the affected volume is cut from the semiconductor and contacts and the simulation grid is switched to a full 3D azimuthal range (`phi` from `0` to `360`). When `false`, these features are ignored and the simulation remains 2D (azimuthally symmetric).

- Add docstring entries for the `allow_cylindrical_asymmetry` keyword to the `SolidStateDetector` and `Simulation` constructors.
- Add a `"Test allow_cylindrical_asymmetry"` testset that verifies a `crack` in the metadata switches the simulation grid to a full 3D azimuthal range (`sim.config_dict["grid"]["axes"]["phi"]["to"] == 360`) when asymmetry is allowed (default), and is ignored (`phi["to"] == 0`) when disabled.
