### PR TITLE
read_ldata: per-detector slicing on event tiers (jlevt / jlskm / jlpmt)

### DIFF
--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -119,8 +119,18 @@ function __init__()
     (@isdefined DataPartition) && extend_datatype_dict(DataPartition, "datapartition")
 end
 
-const _evt_tiers = DataTier.([:jlevt, :jlskm])
+const _evt_tiers = DataTier.([:jlevt, :jlskm, :jlpmt])
 const _perdet_tiers = DataTier.([:jlpeaks, :jlhit, :jlpls])
+
+function _evt_persubdet_path(tier::DataTier, sys::Symbol)
+    if tier == DataTier(:jlevt) || tier == DataTier(:jlskm)
+        sys == :geds && return "$tier/geds"
+        sys == :spms && return "$tier/spms"
+    elseif tier == DataTier(:jlpmt)
+        sys == :pmts && return "$tier"
+    end
+    return nothing
+end
 
 function _lh5_data_open(f::Function, data::LegendData, tier::DataTierLike, filekey::FileKey, det::Union{DetectorIdLike, Nothing}=nothing, mode::AbstractString="r")
     t = DataTier(tier)
@@ -141,10 +151,25 @@ _propfunc_src_columnnames(::PropertyFunctions.PropertyFunction{names}) where nam
 _propfunc_src_columnnames(::Any) = ()
 _propfunc_trg_columnnames(::PropSelFunction{src, trg}) where {src, trg} = trg
 
-_load_all_keys(nt::NamedTuple, n_evts::Int=-1) = if length(nt) == 1 _load_all_keys(nt[first(keys(nt))], n_evts) else NamedTuple{keys(nt)}(map(x -> _load_all_keys(nt[x], n_evts), keys(nt))) end
-_load_all_keys(arr::AbstractArray, n_evts::Int=-1) = arr[:][if (n_evts < 1 || n_evts > length(arr)) 1:length(arr) else rand(1:length(arr), n_evts) end]
-_load_all_keys(t::Table, n_evts::Int=-1) = t[:][if (n_evts < 1 || n_evts > length(t)) 1:length(t) else rand(1:length(t), n_evts) end]
+_sample_idx(n::Int, n_evts::Int) = (n_evts < 1 || n_evts > n) ? (1:n) : rand(1:n, n_evts)
+
+function _load_all_keys(nt::NamedTuple, n_evts::Int=-1)
+    length(nt) == 1 && return _load_all_keys(nt[first(keys(nt))], n_evts)
+    NamedTuple{keys(nt)}(map(k -> _load_all_keys(nt[k], n_evts), keys(nt)))
+end
+_load_all_keys(arr::AbstractArray, n_evts::Int=-1) = arr[:][_sample_idx(length(arr), n_evts)]
+_load_all_keys(t::Table, n_evts::Int=-1) = t[:][_sample_idx(length(t), n_evts)]
 _load_all_keys(x, n_evts::Int=-1) = x
+
+function _propsel_filter_apply(load_col, f::PropSelFunction, filterby::Base.Callable, n_evts::Int)
+    src    = _propfunc_src_columnnames(f)
+    trg    = _propfunc_trg_columnnames(f)
+    needed = Tuple(unique((src..., _propfunc_src_columnnames(filterby)...)))
+    tbl    = Table(NamedTuple{needed}(map(load_col, needed)))
+    filterby !== Returns(true) && (tbl = tbl[coalesce.(filterby.(tbl), false)])
+    n_evts > 0 && (tbl = tbl[1:min(n_evts, length(tbl))])
+    Table(NamedTuple{trg}(Tuple(getproperty(tbl, c) for c in src)))
+end
 
 function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::Int)
     if f isa PropSelFunction && filterby == Returns(true)
@@ -155,6 +180,8 @@ function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::
         else
             NamedTuple{trg_cols}(Tuple(values(columns(_load_all_keys(getproperties(src_cols)(h_node), n_evts)))))
         end)
+    elseif f isa PropSelFunction && filterby isa PropertyFunctions.PropertyFunction
+        return _propsel_filter_apply(name -> getproperty(h_node, name)[:], f, filterby, n_evts)
     else
         lh5_data = _load_all_keys(h_node, n_evts)
         if filterby != Returns(true)
@@ -163,6 +190,123 @@ function _apply_read(h_node, f::Base.Callable, filterby::Base.Callable, n_evts::
         f != identity && (lh5_data = f.(lh5_data))
         TypedTables.Tables.istable(lh5_data) ? Table(lh5_data) : lh5_data
     end
+end
+
+# Flatten LH5 group into `prefix_name => (h5_path, leaf)`; VoV groups (cumulative_length / encoded_data) are leaves.
+function _build_evt_namemap(h::LegendHDF5IO.LHDataStore, tier::DataTier)
+    nmap = Dict{Symbol, Tuple{String, Symbol}}()
+    h5_grp = h.data_store["$tier"]
+    try
+        _walk_evt_h5!(nmap, h5_grp, "$tier", "")
+    finally
+        close(h5_grp)
+    end
+    nmap
+end
+
+function _walk_evt_h5!(out::Dict, group, base_path::String, prefix::String)
+    for k in keys(group)
+        full_name = isempty(prefix) ? Symbol(k) : Symbol(prefix, "_", k)
+        child = group[k]
+        try
+            if child isa LegendHDF5IO.HDF5.Dataset
+                out[full_name] = (base_path, Symbol(k))
+            elseif child isa LegendHDF5IO.HDF5.Group
+                ck = keys(child)
+                if "cumulative_length" in ck || "encoded_data" in ck
+                    out[full_name] = (base_path, Symbol(k))
+                else
+                    new_prefix = isempty(prefix) ? string(k) : "$(prefix)_$(k)"
+                    _walk_evt_h5!(out, child, "$base_path/$k", new_prefix)
+                end
+            end
+        finally
+            close(child)
+        end
+    end
+end
+
+# Per-det flat-prefixed evt-tier read. GED rows masked via `trig_e_det`; SPM/PMT via `detector`.
+function _read_evt_table(h::LegendHDF5IO.LHDataStore, data::LegendData, filekey::FileKey,
+        tier::DataTier, det::DetectorId, f::Base.Callable,
+        filterby::Base.Callable, n_evts::Int)
+
+    nmap = _build_evt_namemap(h, tier)
+
+    sys = channelinfo(data, filekey, det).system
+    persubdet_path = _evt_persubdet_path(tier, sys)
+    persubdet_path === nothing &&
+        error("read_ldata(:$tier, ..., $det): no per-det data in $tier for system :$sys")
+    haskey(h, persubdet_path) ||
+        error("read_ldata(:$tier, ..., $det): /$persubdet_path missing in file")
+    psd = h[persubdet_path]
+
+    has_trig = hasproperty(psd, :trig_e_det)
+    has_det  = hasproperty(psd, :detector)
+    if !has_trig && !has_det
+        if hasproperty(psd, :channel) || hasproperty(psd, :trig_e_ch) || hasproperty(psd, :chevtno)
+            error("read_ldata(:$tier, ..., $det): /$persubdet_path uses the legacy ChannelId schema " *
+                  "(channel/chevtno/trig_e_ch). Per-detector event-tier reads require the DetectorId schema " *
+                  "(detector/detevtno/trig_e_det) — reprocess with jl-v0.6.0+, or use the no-detector read.")
+        end
+        error("read_ldata(:$tier, ..., $det): /$persubdet_path has neither :detector nor :trig_e_det")
+    end
+
+    # GEDs mask on events where det triggered (trig_e_det); SPMs/PMTs on events where det was read out (detector).
+    dl = has_det ? getproperty(psd, :detector)[:] : nothing
+    if has_trig
+        tl = getproperty(psd, :trig_e_det)[:]
+        tkeep = [findfirst(isequal(det), t) for t in tl]
+        mask = .!isnothing.(tkeep)
+        trig_idxs = Int.(tkeep[mask])
+        trig_inner_lens = length.(tl[mask])
+    else
+        mask = [!isnothing(findfirst(isequal(det), t)) for t in dl]
+        trig_idxs = trig_inner_lens = nothing
+    end
+    det_idxs = det_inner_lens = nothing
+    if has_det
+        dkeep = [findfirst(isequal(det), t) for t in dl[mask]]
+        any(isnothing, dkeep) && error("read_ldata(:$tier, ..., $det): detector is in trig_e_det but absent " *
+            "from the `detector` list of the same event in /$persubdet_path (inconsistent event-tier data)")
+        det_idxs = Int.(dkeep)
+        det_inner_lens = length.(dl[mask])
+    end
+
+    # Classify each VoV leaf by name + inner-length: per-trigger (trig_* matching the trigger signature) vs
+    # per-detector-list (matching the detector signature). Everything else (scalars, ged_spm per-fiber) passes through.
+    function load_col(name::Symbol)
+        haskey(nmap, name) ||
+            error("column $name not found in /$tier (available: $(sort(collect(keys(nmap)))))")
+        (path, leaf) = nmap[name]
+        masked = getproperty(h[path], leaf)[:][mask]
+        eltype(masked) <: AbstractVector || return masked
+        inner = length.(masked)
+        if trig_inner_lens !== nothing && startswith(String(leaf), "trig_") && inner == trig_inner_lens
+            return [masked[k][trig_idxs[k]] for k in eachindex(masked)]
+        elseif det_inner_lens !== nothing && inner == det_inner_lens
+            return [masked[k][det_idxs[k]] for k in eachindex(masked)]
+        else
+            return masked
+        end
+    end
+
+    f isa PropSelFunction && (filterby isa PropertyFunctions.PropertyFunction || filterby === Returns(true)) &&
+        return _propsel_filter_apply(load_col, f, filterby, n_evts)
+
+    all_names = Tuple(sort(collect(keys(nmap))))
+    cols = map(load_col, all_names)
+    _apply_read(Table(NamedTuple{all_names}(cols)), f, filterby, n_evts)
+end
+
+# No-detector evt-tier read: per-leaf PropSel via flat nmap; falls back to nested LH5 for back-compat.
+function _read_evt_no_det_table(h::LegendHDF5IO.LHDataStore, tier::DataTier,
+        f::Base.Callable, filterby::Base.Callable, n_evts::Int)
+    f isa PropSelFunction || return _apply_read(h["$tier"], f, filterby, n_evts)
+    nmap = _build_evt_namemap(h, tier)
+    needed = Tuple(unique((_propfunc_src_columnnames(f)..., _propfunc_src_columnnames(filterby)...)))
+    all(c -> haskey(nmap, c), needed) || return _apply_read(h["$tier"], f, filterby, n_evts)
+    _propsel_filter_apply(name -> getproperty(h[nmap[name][1]], nmap[name][2])[:], f, filterby, n_evts)
 end
 
 # Try "tier/det" (current), then "det/tier" (legacy), then bare "tier" (raw/jldsp struct-view).
@@ -183,11 +327,10 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
     has_det = !isempty(string(rsel[3]))
     det_arg = has_det ? DetectorId(rsel[3]) : nothing
 
-    data_tier = _lh5_data_open(data, tier, filekey, det_arg) do h
+    _lh5_data_open(data, tier, filekey, det_arg) do h
         if tier in _evt_tiers
-            # Evt-tier no-det reads return the whole tier table; per-det reads
-            # are post-filtered below to events where the detector triggered.
-            _apply_read(h["$tier"], f, filterby, n_evts)
+            has_det || return _read_evt_no_det_table(h, tier, f, filterby, n_evts)
+            _read_evt_table(h, data, filekey, tier, det_arg, f, filterby, n_evts)
         else
             has_det || throw(ArgumentError("DetectorId required for tier $tier"))
             path = _resolve_perdet_path(h, tier, det_arg)
@@ -200,11 +343,6 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
             _apply_read(h[full], f, filterby, n_evts)
         end
     end
-    if tier in _evt_tiers && has_det
-        data_tier[any.(map.(isequal(det_arg), data_tier.geds.trig_e_det))]
-    else
-        data_tier
-    end
 end
 
 function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey}; kwargs...)
@@ -213,9 +351,10 @@ function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rse
     # List detectors via "tier/<det>" (current) or fall back to "<det>/tier" (legacy).
     dets = _lh5_data_open(data, tier, rsel[2]) do h
         if haskey(h, "$tier")
-            collect(keys(h["$tier"]))
+            filter(k -> LegendDataManagement._can_convert_to(DetectorId, k), collect(keys(h["$tier"])))
         else
-            [k for k in keys(h) if haskey(h, "$k/$tier")]
+            [k for k in keys(h) if h.data_store[k] isa LegendHDF5IO.HDF5.Group &&
+                LegendDataManagement._can_convert_to(DetectorId, k) && haskey(h, "$k/$tier")]
         end
     end
     isempty(dets) && throw(ArgumentError("No detectors found under /$tier in $(basename(data.tier[tier, rsel[2]]))"))
@@ -241,7 +380,6 @@ end
 LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, AbstractVector{FileKey}}; kwargs...) = 
     LegendDataManagement.read_ldata(f, data, (rsel[1], rsel[2], ""); kwargs...)
 
-### Argument distinction for different DataSelector Types
 function _convert_rsel2dsel(rsel::NTuple{<:Any, AbstractDataSelectorLike})
     selector_types = [PossibleDataSelectors[LegendDataManagement._can_convert_to.(PossibleDataSelectors, Ref(s))] for s in rsel]
     if length(selector_types[1]) > 1 && DataTier in selector_types[1]


### PR DESCRIPTION
## What didn't work before
Event-tier files (`jlevt`, `jlskm`, `jlpmt`) store **one row per event**, with every
detector's data packed together in that row. To get a *single* detector's value you
had to load the **entire** event table (all detectors, ~80 columns) and then dig
into the nested `geds` / `spms` / `aux` structure by hand. Inside, the per-detector
values sit in variable-length lists (one list per event), so you also had to find
that detector's slot in each event's list yourself. And the per-detector handling
was hardcoded to germanium (`geds.trig_e_*`) — it didn't work for SiPMs or PMTs.

## Why the change is necessary
Event-level / LAr-veto analysis needs per-detector quantities straight from the
event tier (a GED's calibrated energy per event, a SiPM's PE sum, …). Doing it by
hand is slow (you materialize the whole multi-GB table) and error-prone (you index
the per-event lists yourself), and it only worked for GEDs.

## What works now (in simple words)
- `read_ldata((:geds_e_cusp_ctc_cal, …), l200, (:jlevt, fk, det))` returns a **flat**
  table with simple names (`geds_e_cusp_ctc_cal`, `aux_pulser_aux_trig`, …), already
  **sliced to that detector** — one value per event, not a list.
- Works for **GEDs, SiPMs and PMTs** (the system is detected automatically), not just
  germanium.
- Only the columns you ask for are read from disk, **even when you also pass a
  `filterby`** — so you don't pay for loading the whole table.
- Reading an event tier **without** a detector still returns the original nested view,
  so existing code keeps working.

**Under the hood:** it flattens the nested event group into a `name → path` map,
finds the detector's slot per event via `trig_e_det` (GEDs) or `detector`
(SiPMs/PMTs), and pulls that slot out of each per-event list. Per-trigger vs.
per-detector columns are told apart by name **and** length, so you always get the
right value; an old channel-based file now fails with a clear message instead of
returning wrong numbers.

## Stack
On top of **PR1** (DetectorId-only API) and **PR2** (path resolver / read helper).
Required by **PR4** (cross-tier `filtertier`).
