### PR TITLE
read_ldata: cross-tier filtering via the filtertier kwarg

### DIFF
--- a/ext/LegendDataManagementLegendHDF5IOExt.jl
+++ b/ext/LegendDataManagementLegendHDF5IOExt.jl
@@ -122,6 +122,13 @@ end
 const _evt_tiers = DataTier.([:jlevt, :jlskm, :jlpmt])
 const _perdet_tiers = DataTier.([:jlpeaks, :jlhit, :jlpls])
 
+# Per-(fk, det) row index into raw/jldsp; *_dataidx can be run-wide so we use *_detevtno.
+const _evt_idx_col = Dict{Symbol,Symbol}(
+    :geds => :geds_detevtno,
+    :spms => :spms_detevtno,
+    :pmts => :detevtno,
+)
+
 function _evt_persubdet_path(tier::DataTier, sys::Symbol)
     if tier == DataTier(:jlevt) || tier == DataTier(:jlskm)
         sys == :geds && return "$tier/geds"
@@ -322,10 +329,44 @@ function _resolve_perdet_path(h, tier::DataTier, det::DetectorId)
     nothing
 end
 
-function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey, DetectorIdLike}; filterby::Base.Callable=Returns(true), n_evts::Int=-1, ignore_missing::Bool=false, subgroup::Union{Symbol,Nothing}=nothing, kwargs...)
+function LegendDataManagement.read_ldata(f::Base.Callable, data::LegendData, rsel::Tuple{DataTierLike, FileKey, DetectorIdLike}; filterby::Base.Callable=Returns(true), filtertier::Union{DataTierLike,Nothing}=nothing, n_evts::Int=-1, ignore_missing::Bool=false, subgroup::Union{Symbol,Nothing}=nothing, kwargs...)
     tier, filekey = DataTier(rsel[1]), rsel[2]
     has_det = !isempty(string(rsel[3]))
     det_arg = has_det ? DetectorId(rsel[3]) : nothing
+
+    # Cross-tier filter: event-tier filtertier slices via *_detevtno; per-trigger filtertier (raw/jldsp) uses a row-aligned Bool mask.
+    if filtertier !== nothing && DataTier(filtertier) != tier
+        has_det || throw(ArgumentError("filtertier requires a DetectorId"))
+        ftier = DataTier(filtertier)
+        sliced = if ftier in _evt_tiers
+            tier in _evt_tiers && throw(ArgumentError("filtertier :$ftier and target :$tier are both event tiers; " *
+                "cross-tier *_detevtno slicing maps an event tier onto a per-detector tier (raw/jldsp), not event->event."))
+            sys = channelinfo(data, filekey, det_arg).system
+            idx_col = get(_evt_idx_col, sys, nothing)
+            idx_col === nothing && throw(ArgumentError("No index column known for system :$sys"))
+            idxs = getproperty(LegendDataManagement.read_ldata((idx_col,), data, (ftier, filekey, det_arg); filterby), idx_col)
+            tbl = LegendDataManagement.read_ldata(f, data, (tier, filekey, det_arg); ignore_missing, subgroup, kwargs...)
+            tbl === nothing && return nothing
+            (isempty(idxs) || (minimum(idxs) >= 1 && maximum(idxs) <= length(tbl))) ||
+                throw(ArgumentError("filtertier :$ftier gave row indices outside 1:$(length(tbl)) for :$tier of $det_arg; " *
+                    "likely a *_detevtno vs target-row-count mismatch (schema/period skew)."))
+            tbl[idxs]
+        elseif !(tier in _evt_tiers)
+            filt_cols = _propfunc_src_columnnames(filterby)
+            isempty(filt_cols) && throw(ArgumentError("filterby must be a @pf PropertyFunction with named source columns"))
+            ft_data = LegendDataManagement.read_ldata(filt_cols, data, (ftier, filekey, det_arg))
+            mask = coalesce.(filterby.(ft_data), false)
+            tbl = LegendDataManagement.read_ldata(f, data, (tier, filekey, det_arg); ignore_missing, subgroup, kwargs...)
+            tbl === nothing && return nothing
+            length(mask) == length(tbl) ||
+                throw(ArgumentError("per-trigger filtertier :$ftier row count $(length(mask)) != target :$tier row count " *
+                    "$(length(tbl)) for $det_arg; this 1:1 row alignment only holds between sibling per-trigger tiers (raw <-> jldsp)."))
+            tbl[mask]
+        else
+            throw(ArgumentError("Cannot use non-event filtertier :$ftier when reading event tier :$tier"))
+        end
+        return n_evts > 0 ? sliced[1:min(n_evts, length(sliced))] : sliced
+    end
 
     _lh5_data_open(data, tier, filekey, det_arg) do h
         if tier in _evt_tiers


### PR DESCRIPTION
## What didn't work before
There was no way to filter a read of one tier by a condition that lives in a
*different* tier. Example: "give me this detector's raw waveforms, but only for the
events that pass a quality cut and an energy threshold" — where the cut/threshold are
computed in the `jlevt` (event) tier, not in `raw`. You had to read both tiers
yourself and line them up by hand — and they **don't** line up row-by-row: the event
tier stores, per detector per event, the **row number** in `raw`/`jldsp` where that
event's data sits.

## Why the change is necessary
The natural workflow is "pick interesting events at the event level, then pull their
raw waveforms / DSP values for a detector." Without this you load everything and
align indices manually — slow and easy to get wrong, because the event tier indexes
into `raw`/`jldsp` by a per-detector event number, not by row position.

## What works now (in simple words)
- New `filtertier` kwarg:
  `read_ldata(…, (:raw, fk, det); filterby = <event-level cut>, filtertier = :jlevt)`
  returns only the `raw` rows of that detector for events that pass the cut.
- Works for phy (filter via `jlevt`) and cal (filter via `jldsp`), and symmetrically
  between the sibling per-trigger tiers (`raw` ↔ `jldsp`).
- Still only loads the columns you actually need.

**Under the hood:**
- Event-tier filter: it reads the detector's per-event index column (`*_detevtno`,
  which points at the matching `raw`/`jldsp` row) for the events passing `filterby`,
  then takes exactly those rows from the target tier. (`*_detevtno` is the 1-based
  per-(filekey, detector) row index — unlike `*_dataidx`, which is run-wide in some
  datasets.)
- Sibling per-trigger filter (`raw` ↔ `jldsp`): these are 1:1 row-aligned per
  detector, so it builds a boolean mask from `filterby` and applies it.
- Guards (clear errors instead of silent wrong results): rejects event↔event combos,
  bounds-checks the indices, asserts the 1:1 alignment, and respects `ignore_missing`.

## Stack
Top of the `read_ldata` stack: builds on **PR1** (DetectorId-only API), **PR2** (path
resolver / read helper) and **PR3** (per-detector event-tier slicing). Nothing builds
on it.
