### PR TITLE
docs + tests: document the new read_ldata API (+ disabled integration suite & benchmark)

### DIFF
--- a/docs/src/extensions.md
+++ b/docs/src/extensions.md
@@ -62,58 +62,209 @@ The following additional keywords arguments can be set (the `plot_waveform` kwar
 
 ## `LegendHDF5IO` extension
 
-LegendDataManagment provides an extension for [LegendHDF5IO](https://github.com/legend-exp/LegendHDF5IO.jl).
-This makes it possible to directly load LEGEND data from HDF5 files via the `read_ldata` function. The extension is automatically loaded when both packages are loaded. 
-Example (requires a `$LEGEND_DATA_CONFIG` environment variable pointing to a legend data-config file):
-    
-```julia
-using LegendDataManagement, LegendHDF5IO
-l200 = LegendData(:l200)
-filekeys = search_disk(FileKey, l200.tier[:jldsp, :cal, :p03, :r000])
+LegendDataManagement provides an extension for [LegendHDF5IO](https://github.com/legend-exp/LegendHDF5IO.jl) that exposes `read_ldata` for loading LEGEND data from HDF5 files. The extension auto-loads when both packages are loaded. All examples assume `$LEGEND_DATA_CONFIG` is set.
 
-chinfo = channelinfo(l200, (:p03, :r000, :cal); system=:geds, only_processable=true)
-
-ch = chinfo[1].channel
-
-dsp = read_ldata(l200, :jldsp, first(filekeys), ch)
-dsp = read_ldata(l200, :jldsp, :cal, :p03, :r000, ch)
-dsp = read_ldata((:e_cusp, :e_trap, :blmean, :blslope), l200, :jldsp, :cal, :p03, :r000, ch)
-```
-`read_ldata` automitcally loads LEGEND data for a specific `DataTier` and data selection like e.g. a `FileKey` or a run-selection based for a given `ChannelId`. The `search_disk` function allows the user to search for available `DataTier` and `FileKey` on disk. The first argument can be either a selection of keys in form of a `NTuple` of `Symbol` or a [PropertyFunction](https://github.com/oschulz/PropertyFunctions.jl/tree/main) which will be applied during loading. 
-It is also possible to load whole a `DataPartition` or `DataPeriod` for a given `ChannelId` ch:
 ```julia
-dsp = read_ldata(l200, :jldsp, :cal, DataPartition(1), ch)
-dsp = read_ldata(l200, :jldsp, :cal, DataPeriod(3), ch)
-```
-In additon, it is possible to load a random selection of `n_evts` events randomly selected from each loaded file:
-```julia
-dsp = read_ldata(l200, :jldsp, :cal, :p03, :r000, ch; n_evts=1000)
-```
-For simplicity, the ch can also be given as a `DetectorID` which will be converted internally to a `ChannelId`:
-```julia
-det = chinfo[1].detector
-dsp = read_ldata(l200, :jldsp, :cal, :p03, :r000, det)
-```
-In case, a `ChannelId` is missing in a file, the function will throw an `ArgumentError`. To avoid this and return `nothing` instead, you can use the `ignore_missing` keyword argument.
+ENV["LEGEND_DATA_CONFIG"] = "."
 
-The data can be filtered by a `filterby` keyword argument which is a [PropertyFunction](https://github.com/oschulz/PropertyFunctions.jl/tree/main) applied to each chunk of loaded data:
-```julia
-dsp = read_ldata(l200, :jldsp, :cal, :p03, :r000, ch; filterby=@pf($e_trap > 0.0))
-```
-This will only load data where the `e_trap` property is greater than 0.
+using LegendDataManagement, LegendHDF5IO, PropertyFunctions
+using Unitful: @u_str
 
-It is possible to read in multiple files in parallel using the `Distributed` functionalities from within a session. You can activate parallel read with the `parallel` kwarg.
-``` julia
-dsp = read_ldata(l200, :jldsp, :cal, DataPeriod(3), ch)
-dsp = read_ldata(l200, :jldsp, :cal, DataPeriod(3), ch; parallel=true)
+l200    = LegendData(:l200)
+fk_cal  = first(search_disk(FileKey, l200.tier[:jldsp, :cal, :p18, :r000]))
+fk_phy  = first(search_disk(FileKey, l200.tier[:raw,   :phy, :p18, :r000]))
+fks_phy = search_disk(FileKey, l200.tier[:raw, :phy, :p18, :r000])
+det     = first(filter(c -> c.system == :geds && c.processable, channelinfo(l200, fk_cal))).detector
 ```
-However, it is necessary that a worker allocation was already performed and the `LegendDataManagement` as well as `LegendHDF5IO` package is loaded on all workers, e.g. with
-``` julia
+
+### Tier overview
+
+| Tier(s) | File layout | `(tier, fk)` no-det | `(tier, fk, det)` with det | `subgroup` | per-det evt slicing |
+|---------|-------------|---------------------|----------------------------|------------|---------------------|
+| `:raw`, `:jldsp`               | shared, struct-view per det | `NamedTuple{det → Table}` (multi-det discovery) | `Table`                                  | ✓ | — |
+| `:jlhit`, `:jlpls`, `:jlpeaks` | one file per `(run, det)`   | — (det is required)                             | `Table`                                  | ✓ | — |
+| `:jlevt`, `:jlskm`             | shared evt-file             | nested LH5 / flat-leaf PropSel                  | flat per-det `Table` (mask + VoV unwrap) | — | GED, SPM |
+| `:jlpmt`                       | shared evt-file             | nested LH5 / flat-leaf PropSel                  | flat per-PMT `Table`                     | — | PMT |
+
+`PropSel`, `filterby`, `filtertier`, and `n_evts` work across all tiers. The detector system (`:geds`, `:spms`, `:pmts`) is auto-detected from `channelinfo` — no need to pass it.
+
+### Call forms
+
+The third positional argument is an `rsel` tuple; you can also spread its elements positionally (`read_ldata(data, tier, args...)`). All forms accept the kwargs from the sections below. Multi-filekey, multi-run, and partition forms additionally accept `parallel=true` and `wpool::WorkerPool`.
+
+```julia
+# By filekey (use any tier — :raw, :jldsp, :jlhit, :jlevt, …)
+read_ldata(l200, :raw,   fk_phy)                              # (tier, fk)              no det → NamedTuple per det
+read_ldata(l200, :jldsp, fk_cal, det)                         # (tier, fk, det)
+read_ldata(l200, :raw,   fks_phy, det)                        # (tier, [fks], det)      multi-fk
+
+# By period / run / partition
+read_ldata(l200, :jldsp, :cal, :p03, :r000)                   # (tier, cat, period, run)        no det
+read_ldata(l200, :raw,   :phy, :p03, :r000, det)              # (tier, cat, period, run, det)
+read_ldata(l200, :jldsp, :cal, :p03, det)                     # (tier, cat, period, det)
+read_ldata(l200, :jldsp, :cal, DataPartition(1), det)         # (tier, cat, partition, det)
+
+# Custom run set (Table with :period and :run columns)
+runs = partitioninfo(l200, det, DataPartition(1))
+read_ldata(l200, :jldsp, :cal, runs, det)                     # (tier, cat, Table{period,run}, det)
+```
+
+Strings and symbols (`":cal"`, `":p03"`, `:r000`) are interchangeable with typed selectors (`DataCategory(:cal)`, `DataPeriod(3)`, `DataRun(0)`).
+
+All shapes work for `:raw`, `:jldsp` and the event tiers in both with-det and no-det form (no-det returns a `NamedTuple` keyed by detector). The per-det tiers (`:jlhit`, `:jlpls`, `:jlpeaks`) require a detector in every shape — no-det forms throw because the file resolver needs the det to find the file.
+
+### Column selection (`PropSel`)
+
+```julia
+read_ldata(l200, :jldsp, fk_cal, det)                                              # all columns
+read_ldata(:e_cusp, l200, (:jldsp, fk_cal, det))                                   # bare Symbol  → (:e_cusp,)
+read_ldata((:e_cusp, :timestamp), l200, (:jldsp, fk_cal, det))                     # tuple of names
+read_ldata(@pf((; $e_cusp, $timestamp)), l200, (:jldsp, fk_cal, det))              # PropSel via @pf
+read_ldata(@pf((; bltime = $timestamp * $blmean)), l200, (:jldsp, fk_cal, det))  # rename via @pf
+```
+
+`PropSel` triggers a fast path that only loads the requested leaf columns. Combined with `filterby`, the union of source columns is loaded once.
+
+### Filtering (`filterby`)
+
+`filterby` takes a `PropertyFunction` evaluated row-wise; rows where the predicate is `missing` are dropped (same as `false`). When `@pf` is used inline as a kwarg, wrap the body in parens — `filterby = @pf(...)` — otherwise the macro stops at the next comma and PropertyFunctions fails with `invalid assignment location`.
+
+```julia
+# Single condition
+read_ldata((:e_cusp,), l200, (:jldsp, fk_cal, det); filterby = @pf($e_cusp > 1000))
+
+# Multi-column cut on a per-det jlevt Table
+read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, fk_phy, det);
+           filterby = @pf($geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV"))
+
+# Cross-subgroup QC: geds + ged_spm + !aux_muonveto + !aux_pulser
+read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, fk_phy, det);
+           filterby = @pf($geds_is_valid_qc && $ged_spm_is_valid_lar &&
+                          !$aux_muonveto_aux_trig && !$aux_pulser_aux_trig))
+```
+
+`@pf $col` (flat source name) enables the fast path; `@pf $a.b.c` (dot-chain) is evaluated on the whole loaded object — use this with the nested no-detector LH5 view.
+
+### Cross-tier filter (`filtertier`)
+
+`filtertier` evaluates `filterby` on a *different* tier than the one being read and slices the target by the derived alignment. Requires a detector.
+
+| Filter source                        | Target                               | Mechanism |
+|--------------------------------------|--------------------------------------|-----------|
+| evt-tier (`jlevt`, `jlskm`, `jlpmt`) | any                                  | per-det `*_detevtno` slicing (`geds_detevtno`, `spms_detevtno`, `detevtno`) |
+| `raw`, `jldsp`                       | non-evt (`raw`, `jldsp`, `jlhit`, …) | per-trigger 1:1 row-aligned `Bool` mask |
+
+| target ↓ \ source →         | `jlevt` | `jlskm` | `jlpmt` | `raw` | `jldsp` |
+|-----------------------------|---------|---------|---------|-------|---------|
+| `jlevt`                     | —       | ✓       | ✓       | ✗     | ✗       |
+| `jlskm`                     | ✓       | —       | ✓       | ✗     | ✗       |
+| `jlpmt`                     | ✓       | ✓       | —       | ✗     | ✗       |
+| `raw`                       | ✓       | ✓       | ✓       | —     | ✓       |
+| `jldsp`                     | ✓       | ✓       | ✓       | ✓     | —       |
+| `jlhit`, `jlpeaks`, `jlpls` | ✓       | ✓       | ✓       | ✓¹    | ✓¹      |
+
+`✗` evt-tier target with non-evt source: rejects with `ArgumentError`. `—` filter tier equals target: skipped. `✓¹` allowed but caller must ensure 1:1 row alignment.
+
+```julia
+# Raw waveforms of phy events that pass an event-tier QC + energy cut
+read_ldata(@pf((; $waveform_presummed, $timestamp)),
+           l200, (:raw, fk_phy, det);
+           filterby   = @pf($geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV"),
+           filtertier = :jlevt)
+
+# jldsp filtered by an event-tier predicate
+read_ldata((:e_cusp, :t50), l200, (:jldsp, fk_phy, det);
+           filterby = @pf($ged_spm_is_valid_lar == true), filtertier = :jlevt)
+
+# Cal raw waveforms with a dsp-energy cut (cal has no jlevt)
+read_ldata((:waveform_presummed,), l200, (:raw, fk_cal, det);
+           filterby = @pf($e_cusp > 1000), filtertier = :jldsp)
+
+# Symmetric direction (jldsp filtered by raw column, e.g. daqenergy)
+read_ldata((:e_cusp,), l200, (:jldsp, fk_phy, det);
+           filterby = @pf($daqenergy > 100), filtertier = :raw)
+```
+
+### Per-detector event-tier reads (`:jlevt`, `:jlskm`, `:jlpmt`)
+
+With a detector, event-tier reads return a flat-prefixed Table whose rows are restricted to events where that detector participated. Per-trigger and per-det-list VoV columns are unwrapped at the detector's slot; scalar columns pass through.
+
+| Tier     | GED | SPM | PMT |
+|----------|-----|-----|-----|
+| `:jlevt` |  ✓  |  ✓  |  ✗  |
+| `:jlskm` |  ✓  |  ✓  |  ✗  |
+| `:jlpmt` |  ✗  |  ✗  |  ✓  |
+
+`✗` throws `no per-det data in <tier> for system :<sys>`. Mask source: `trig_e_det` (per-trigger, preferred for GED) falls back to `detector` (per-det-list, used for SPM/PMT). Cross-system columns (e.g. `ged_spm_*`) are indexed at the matching system's slot via the column's inner-length signature.
+
+```julia
+read_ldata((:geds_e_cusp_ctc_cal, :geds_trig_e_cusp_ctc_cal),
+           l200, (:jlevt, fk_phy, det))
+```
+
+Columns are flat-prefixed by sub-group: `geds_e_cusp_ctc_cal`, `spms_trig_max_cal`, `aux_pulser_aux_trig`, `ged_spm_is_valid_lar`, etc. The name-map is built dynamically by walking the HDF5 group, so new sub-groups need no code change.
+
+### No-detector event-tier reads
+
+Without a detector, event-tier reads return either:
+
+- **flat-leaf PropSel** — when `PropSel` requests only flat leaves (e.g. `:geds_multiplicity`, `:aux_pulser_aux_trig`), only those columns are loaded. No detector mask — every event is returned.
+- **nested LH5** — otherwise (no PropSel, or PropSel asks for a whole sub-group like `:geds`), the native nested layout is preserved (back-compat for callers like `process_evt_phy`).
+
+```julia
+# Flat-leaf PropSel
+read_ldata((:geds_multiplicity, :aux_forcedtrigger_aux_trig), l200, (:jlevt, fk_phy))
+
+# Nested LH5 view
+evt = read_ldata(l200, :jlevt, fk_phy)
+evt.aux.pulser.aux_trig          # Vector{Bool}
+evt.geds.is_valid_qc             # Vector{Bool}
+evt.geds.detector                # VoV{DetectorId} — per event, list of triggered dets
+evt.geds.e_cusp_ctc_cal          # VoV{Float}     — per event, list of energies
+```
+
+### Sub-group descent (`subgroup`)
+
+For tiers that nest data inside per-detector groups (e.g. `jlhit/<det>/dataQC`):
+
+```julia
+read_ldata(@pf((; $e_cusp, $timestamp)), l200, (:jlhit, fk_cal, det); subgroup=:dataQC)
+read_ldata((:is_physical,),              l200, (:jlhit, fk_cal, det); subgroup=:qc)
+read_ldata((:daqenergy, :timestamp),     l200, (:jlpls, fk_cal, "PULS01"); subgroup=:tags)
+```
+
+The kwarg is ignored on evt-tier reads (which already use a flat-prefixed structure).
+
+### Multi-detector discovery
+
+For `:raw` and `:jldsp`, calling without a detector returns a `NamedTuple` keyed by detector ID:
+
+```julia
+all = read_ldata(l200, :jldsp, fk_cal)      # NamedTuple — all dets in this filekey
+all.B00000C.e_cusp                          # access by detector name
+```
+
+Per-det tiers (`:jlhit`, `:jlpls`, `:jlpeaks`) cannot be read this way — they require a det in every call.
+
+### Distributed reads
+
+Multi-filekey, multi-run, and partition forms accept `parallel=true` and a custom `wpool::WorkerPool`:
+
+```julia
 using Distributed
 addprocs(4)
 @everywhere using LegendDataManagement, LegendHDF5IO
+
+read_ldata((:e_cusp,), l200, (:jldsp, fks_phy, det);
+           filterby = @pf($e_cusp > 0), parallel=true)
 ```
-In addition, the `wpool`kwarg allows to parse a custome `WorkerPool` for more sophisticated load patterns.
+
+Workers must have both packages loaded. Without `parallel=true`, the per-filekey reads are sequential with a progress bar; with it, `progress_pmap` distributes them across the worker pool.
+
+### Other kwargs
+
+- `n_evts=1000` — limit to `n_evts` rows per file. On `PropSel + filterby` paths, applied after the filter (first `n_evts` survivors); on the eager fallback, may random-sample at load.
+- `ignore_missing=true` — return `nothing` instead of throwing when a detector is missing from a per-det / shared tier file (does not apply to evt-tier reads).
 
 ## `SolidStateDetectors` extension
 

--- a/test/test_ext_legendhdf5io.jl
+++ b/test/test_ext_legendhdf5io.jl
@@ -137,3 +137,126 @@ using HDF5
         end # tmpdir
     end
 end
+
+# ============================================================================
+#  read_ldata — new DetectorId API integration tests:
+#  per-detector event-tier slicing, filtertier (cross-tier filter), subgroup
+#  descent, the PropSel+filterby fast path, and a fast-path-vs-load-all benchmark.
+#
+#  DISABLED by default: these need real new-schema (jl-v0.6.0+) tier data, which
+#  is NOT shipped via LegendTestData. To ACTIVATE:
+#    1. point LEGEND_DATA_CONFIG at a config over jl-v0.6.0+ data, e.g.
+#         ENV["LEGEND_DATA_CONFIG"] =
+#             "/ptmp/oschulz/legend/data/l200/tmp/jl-v0.6.0dev7/config.json"
+#    2. set PER / RUN / CALRUN below to a period and runs present in your data
+#    3. delete the surrounding  #=  …  =#
+# ============================================================================
+#=
+using Unitful: @u_str
+
+@testset "read_ldata new API (jl-v0.6.0+ data)" begin
+    l200 = LegendData(:l200)
+    PER, RUN, CALRUN = DataPeriod(19), DataRun(2), DataRun(5)
+
+    fks_phy = search_disk(FileKey, l200.tier[:raw, :phy, PER, RUN])
+    FK_PHY  = first(fks_phy)
+    FK_CAL  = first(search_disk(FileKey, l200.tier[:jldsp, :cal, PER, CALRUN]))
+
+    chinfo  = channelinfo(l200, FK_PHY)
+    DET_GED = first(filter(c -> c.system == :geds && c.processable, chinfo)).detector
+    DET_SPM = first(filter(c -> c.system == :spms, chinfo)).detector
+
+    @testset "column selection — three equivalent forms (+ rename)" begin
+        full = read_ldata(l200, :jldsp, FK_PHY, DET_GED)
+        @test full isa Table
+        @test read_ldata(:e_cusp, l200, (:jldsp, FK_PHY, DET_GED)).e_cusp == full.e_cusp
+        @test read_ldata((:e_cusp, :timestamp), l200, (:jldsp, FK_PHY, DET_GED)).e_cusp == full.e_cusp
+        @test read_ldata(@pf((; $e_cusp, $timestamp)), l200, (:jldsp, FK_PHY, DET_GED)).e_cusp == full.e_cusp
+        @test read_ldata(@pf((; energy = $e_cusp)), l200, (:jldsp, FK_PHY, DET_GED)).energy == full.e_cusp
+    end
+
+    @testset "per-detector across tiers (system auto-detected)" begin
+        @test read_ldata((:waveform_presummed,), l200, (:raw,   FK_PHY, DET_GED)) isa Table
+        @test read_ldata((:waveform_bit_drop,),  l200, (:raw,   FK_PHY, DET_SPM)) isa Table
+        @test read_ldata((:e_cusp, :t50),        l200, (:jldsp, FK_PHY, DET_GED)) isa Table
+    end
+
+    @testset "subgroup descent (jlhit / jlpls)" begin
+        @test read_ldata((:e_cusp,),    l200, (:jlhit, FK_CAL, DET_GED); subgroup=:dataQC) isa Table
+        @test read_ldata((:daqenergy,), l200, (:jlpls, FK_CAL, "PULS01"); subgroup=:tags)  isa Table
+        @test_throws ArgumentError read_ldata((:e_cusp,), l200, (:jlhit, FK_CAL, DET_GED); subgroup=:nope)
+    end
+
+    @testset "event tier + detector -> flat-prefixed, sliced table" begin
+        evt = read_ldata((:geds_e_cusp_ctc_cal, :geds_trig_e_cusp_ctc_cal),
+                         l200, (:jlevt, FK_PHY, DET_GED))
+        @test evt isa Table
+        @test :geds_e_cusp_ctc_cal      in propertynames(evt)
+        @test :geds_trig_e_cusp_ctc_cal in propertynames(evt)
+        @test eltype(evt.geds_e_cusp_ctc_cal) <: Union{Missing, Number}   # sliced to scalars, not VoV
+        # no detector -> native nested LH5 view (back-compat)
+        nested = read_ldata(l200, :jlevt, FK_PHY)
+        @test hasproperty(nested, :geds)
+    end
+
+    @testset "filterby on flat names (single + cross-subgroup)" begin
+        base = read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, FK_PHY, DET_GED))
+        sel  = read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, FK_PHY, DET_GED);
+                          filterby = @pf $geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 20u"keV")
+        @test sel isa Table
+        @test length(sel) <= length(base)
+        # cross-subgroup QC: geds + ged_spm + !aux_muonveto + !aux_pulser
+        sel2 = read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, FK_PHY, DET_GED);
+                          filterby = @pf $geds_is_valid_qc && $ged_spm_is_valid_lar &&
+                                         !$aux_muonveto_aux_trig && !$aux_pulser_aux_trig)
+        @test sel2 isa Table
+        @test length(sel2) <= length(base)
+    end
+
+    @testset "filtertier — cross-tier filter" begin
+        # (1) raw waveforms of phy events passing a jlevt QC + trigger-energy cut
+        raw = read_ldata(@pf((; $waveform_presummed, $timestamp)), l200, (:raw, FK_PHY, DET_GED);
+                         filterby   = @pf $geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV",
+                         filtertier = :jlevt)
+        @test raw isa Table
+        # (2) symmetric per-trigger: jldsp filtered via raw
+        @test read_ldata((:e_cusp,), l200, (:jldsp, FK_PHY, DET_GED);
+                         filterby = (@pf $daqenergy > 100), filtertier = :raw) isa Table
+        # (3) cal raw filtered via cal jldsp (no jlevt for cal)
+        @test read_ldata((:waveform_presummed,), l200, (:raw, FK_CAL, DET_GED);
+                         filterby = (@pf $e_cusp > 1000), filtertier = :jldsp) isa Table
+    end
+
+    @testset "edge cases" begin
+        @test length(read_ldata((:e_cusp,), l200, (:jldsp, FK_PHY, DET_GED); n_evts=500)) <= 500
+        # validly-formatted but absent detector: ignore_missing -> nothing; otherwise throws
+        @test read_ldata((:e_cusp,), l200, (:jldsp, FK_PHY, "V99999A"); ignore_missing=true) === nothing
+        @test_throws ArgumentError read_ldata((:e_cusp,), l200, (:jldsp, FK_PHY, "V99999A"))
+        # filtertier needs a DetectorId
+        @test_throws ArgumentError read_ldata((:e_cusp,), l200, (:jldsp, FK_PHY); filtertier=:raw)
+        # event<->event filtertier rejected
+        @test_throws ArgumentError read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlpmt, FK_PHY, DET_GED);
+                                              filterby=(@pf $geds_is_valid_qc), filtertier=:jlevt)
+    end
+
+    @testset "multi-filekey / period / run forms" begin
+        @test read_ldata((:e_cusp,), l200, (:jldsp, fks_phy[1:min(2, length(fks_phy))], DET_GED)) isa Table
+        @test read_ldata((:e_cusp,), l200, (:jldsp, :phy, PER, RUN, DET_GED)) isa Table
+    end
+
+    @testset "fast path is lighter + faster than load-all-then-filter" begin
+        f    = @pf((; $geds_e_cusp_ctc_cal))
+        filt = @pf $geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV"
+        read_ldata(f, l200, (:jlevt, FK_PHY, DET_GED); filterby=filt)   # warm up (compile)
+        read_ldata(l200, (:jlevt, FK_PHY, DET_GED))
+        fast = @timed read_ldata(f, l200, (:jlevt, FK_PHY, DET_GED); filterby=filt)
+        slow = @timed begin
+            full = read_ldata(l200, (:jlevt, FK_PHY, DET_GED))          # all flat columns materialized
+            full[coalesce.(filt.(full), false)]                         # then filter in memory
+        end
+        @info "read_ldata fast-path benchmark" fast_s=fast.time slow_s=slow.time fast_MB=fast.bytes/1e6 slow_MB=slow.bytes/1e6
+        @test fast.bytes < slow.bytes     # loads only the needed columns
+        @test fast.time  < slow.time      # and is faster
+    end
+end
+=#


### PR DESCRIPTION
Documents the refactored `read_ldata` API in the `LegendHDF5IO` extension docs, and
adds an integration test suite + a fast-path benchmark. The code itself lands in the
stacked PRs (DetectorId-only API → internals/path resolver → per-detector event-tier
slicing → cross-tier `filtertier`); this PR is **docs + tests** only.

## What the new API does (summary)

1. **`DetectorId` throughout.** `read_ldata` accepts `DetectorIdLike` only; the
   channel helpers and the partition-method channel-consistency check are gone.
2. **Tier classification.** `_evt_tiers = [:jlevt, :jlskm, :jlpmt]` and
   `_perdet_tiers = [:jlpeaks, :jlhit, :jlpls]` drive dispatch. raw/jldsp use
   `_resolve_perdet_path`, which tries `tier/<det>` (current), `<det>/tier`
   (legacy), then bare `tier` (struct-view) in order.
3. **Per-detector event-tier slicing.** With a detector,
   `read_ldata(_, l200, (:jlevt, fk, det))` returns a flat-prefixed `Table`
   (`geds_e_cusp_ctc_cal`, `geds_trig_e_cusp_ctc_cal`, `aux_pulser_aux_trig`,
   `ged_spm_is_valid_lar`, …). The name-map is built by walking the HDF5 group;
   per-trigger vs. per-detector-list VoVs are distinguished by **leaf name +
   inner-length signature** (name disambiguates the case `#triggers == #detectors`)
   and unwrapped at the detector's per-event slot.
4. **Cross-tier filter.** The `filtertier` kwarg lets a per-detector raw/jldsp read
   be filtered by an event-tier predicate (sliced via the per-det **`*_detevtno`**
   column — the 1-based per-(filekey, detector) row index; `*_dataidx` is run-wide
   in some datasets and is **not** used) or by a sibling per-trigger tier
   (1:1 row alignment per detector). Works for phy and cal.
5. **Sub-group descent.** `subgroup=:dataQC` for `tier/<det>/group` layouts (jlhit).
6. **Missing-tolerant filter.** Rows where `filterby` returns `missing` are dropped.

A legacy event-tier file (channel/`chevtno`/`trig_e_ch` schema) is rejected with a
clear error rather than silently mis-sliced.


## Performance

PropSel + `filterby` + `filtertier` fast path vs. eager-load-then-filter on real
L200 data (FK p18-r000, B00000C, min of 3 trials):

| Case                                              | speed-up | memory  |
|---------------------------------------------------|---------:|--------:|
| A — raw column selection (waveforms)              |     1.3× |    2.1× |
| B — jldsp column + filter (`e_cusp > 0`)          |     1.0× |    1.0× |
| C — jlevt event-scalar filter (cross-subgroup QC) |    40.0× |   42.3× |
| D — jlevt trigger-energy filter (`>1500 keV`)     |    33.7× |   31.7× |
| E — cross-tier (`filtertier=:jlevt`, phy)         |    32.4× |   26.0× |
| F — cross-tier (`filtertier=:jldsp`, cal)         |     1.6× |    2.0× |

The big wins (C–E) come from never materializing the ~1.3 GB full `jlevt+det` Table
when only a few columns are needed. Per-det raw/dsp reads (A, B, F) are smaller files
to begin with, so the absolute numbers are modest but still favorable.



## Minimal working example

```julia
ENV["LEGEND_DATA_CONFIG"] = "/path/to/your/config.json"   # jl-v0.6.0+ data
using LegendDataManagement, LegendHDF5IO, PropertyFunctions
using Unitful: @u_str

l200     = LegendData(:l200)
PER, RUN = DataPeriod(18), DataRun(0)
FK_PHY   = first(search_disk(FileKey, l200.tier[:raw, :phy, PER, RUN]))
FK_CAL   = first(search_disk(FileKey, l200.tier[:raw, :cal, PER, RUN]))
chinfo   = channelinfo(l200, FK_PHY)
DET_GED  = first(filter(c -> c.system == :geds && c.processable, chinfo)).detector
DET_SPM  = first(filter(c -> c.system == :spms, chinfo)).detector

# Column selection — three equivalent forms
read_ldata(l200, :jldsp, FK_PHY, DET_GED)                                 # full
read_ldata((:e_cusp, :timestamp), l200, (:jldsp, FK_PHY, DET_GED))        # tuple
read_ldata(@pf((; $e_cusp, $timestamp)), l200, (:jldsp, FK_PHY, DET_GED)) # @pf

# Per-detector across tiers (system auto-detected) + sub-group descent
read_ldata((:waveform_presummed,), l200, (:raw,   FK_PHY, DET_GED))
read_ldata((:waveform_bit_drop,),  l200, (:raw,   FK_PHY, DET_SPM))
read_ldata((:e_cusp,),             l200, (:jlhit, FK_CAL, DET_GED); subgroup=:dataQC)
read_ldata((:daqenergy,),          l200, (:jlpls, FK_CAL, "PULS01"); subgroup=:tags)

# Event tier + detector → flat-prefixed Table, sliced to the detector
read_ldata((:geds_e_cusp_ctc_cal, :geds_trig_e_cusp_ctc_cal),
           l200, (:jlevt, FK_PHY, DET_GED))

# Flat-name filter, incl. cross-subgroup QC (geds + ged_spm + aux)
read_ldata((:geds_e_cusp_ctc_cal,), l200, (:jlevt, FK_PHY, DET_GED);
           filterby = @pf $geds_is_valid_qc && $ged_spm_is_valid_lar &&
                          !$aux_muonveto_aux_trig && $geds_trig_e_cusp_ctc_cal > 20u"keV")

# Cross-tier filter: raw waveforms of phy events passing a jlevt cut
read_ldata(@pf((; $waveform_presummed, $timestamp)), l200, (:raw, FK_PHY, DET_GED);
           filterby   = @pf $geds_is_valid_qc && $geds_trig_e_cusp_ctc_cal > 1500u"keV",
           filtertier = :jlevt)

# Cal raw filtered via cal jldsp (no jlevt for cal); symmetric raw ↔ jldsp
read_ldata((:waveform_presummed,), l200, (:raw, FK_CAL, DET_GED);
           filterby = (@pf $e_cusp > 1000), filtertier = :jldsp)

# Multi-filekey / period / partition; other kwargs
read_ldata((:e_cusp,), l200, (:jldsp, :phy, PER, RUN, DET_GED))
read_ldata((:e_cusp,), l200, (:jldsp, FK_PHY, DET_GED); n_evts=1000)
read_ldata((:e_cusp,), l200, (:jldsp, FK_PHY, "V99999A"); ignore_missing=true)  # → nothing

# Event tier WITHOUT a detector → native nested LH5 view (use dot syntax)
evt = read_ldata(l200, :jlevt, FK_PHY; filterby = @pf $geds.is_valid_qc == true)
evt.geds.e_cusp_ctc_cal   # VoV per event
evt.aux.pulser.aux_trig   # Vector{Bool}
