### PR TITLE
Remove channelinfo recursion

### DIFF
--- a/src/legend_data.jl
+++ b/src/legend_data.jl
@@ -443,7 +443,10 @@ export channelinfo
 function channelinfo(data::LegendData, sel::RunCategorySelLike; kwargs...)
     channelinfo(data, start_filekey(data, sel); kwargs...)
 end
-channelinfo(data::LegendData, sel...; kwargs...) = channelinfo(data, sel; kwargs...)
+function channelinfo(data::LegendData, sel::Vararg{Any,N}; kwargs...) where {N}
+    N == 1 && throw(MethodError(channelinfo, (data, sel[1])))
+    channelinfo(data, sel; kwargs...)
+end
 function channelinfo(data::LegendData, sel::Tuple{<:DataPeriodLike, <:DataRunLike, <:DataCategoryLike, Union{ChannelIdLike, DetectorIdLike}}; kwargs...)
     channelinfo(data, ((sel[1:3]), sel[4]); kwargs...)
 end

--- a/test/test_legend_data.jl
+++ b/test/test_legend_data.jl
@@ -48,6 +48,10 @@ include("testing_utils.jl")
         @test !any(iszero.(uncertainty.(extended.fccd)))
         @test !any(iszero.(uncertainty.(extended.active_volume)))
 
+        # Check error handling for invalid input
+        @test_throws MethodError channelinfo(l200, filekey.period, filekey.run)
+        @test_throws MethodError channelinfo(l200, filekey.period)
+
         # ToDo: Make type-stable:
         # @test #=@inferred=#(channel_info(l200, filekey)) isa StructArray
         # chinfo = channel_info(l200, filekey)


### PR DESCRIPTION
Currently calling `chinfo = channelinfo(l200, period, run)` leads to an silent infinite recursion, because it continioulsy calls this catch-all: `channelinfo(data::LegendData, sel...; kwargs...) = channelinfo(data, sel; kwargs...)` that turns arguments into a tuple.
I changed the function so that this infinite loop can no longer happen, as it checks id the tuple was already created.
Calling `chinfo = channelinfo(l200, period, run)` now directly throws an error.